### PR TITLE
user search on admin side

### DIFF
--- a/apps/kita/app/Http/Controllers/Member/MemberController.php
+++ b/apps/kita/app/Http/Controllers/Member/MemberController.php
@@ -20,8 +20,7 @@ class MemberController extends Controller
         $keywords = $searchRequest->only(['name', 'email']);
 
         if (!empty($keywords)) {
-            $escapedKeyword = $memberService->escapeKeyword($keywords);
-            $members = $memberService->getSearchedMembers($escapedKeyword);
+            $members = $memberService->getSearchedMembers($keywords);
         }else{
             $members = $memberService->getMembers();
         }

--- a/apps/kita/app/Http/Controllers/Member/MemberController.php
+++ b/apps/kita/app/Http/Controllers/Member/MemberController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Member;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Member\SearchRequest;
 use App\Services\MemberService;
 
 class MemberController extends Controller
@@ -10,11 +11,20 @@ class MemberController extends Controller
     /**
      * 会員一覧表示
      *
+     * @param App\Services\MemberService $memberService
+     * @param App\Http\Requests\Member\SearchRequest $searchRequest
      * @return \Illuminate\Contracts\View\View
      */
-    public function index(MemberService $memberService)
+    public function index(MemberService $memberService, SearchRequest $searchRequest)
     {
-        $members = $memberService->getMembers();
+        $keywords = $searchRequest->only(['name', 'email']);
+
+        if (!empty($keywords)) {
+            $escapedKeyword = $memberService->escapeKeyword($keywords);
+            $members = $memberService->getSearchedMembers($escapedKeyword);
+        }else{
+            $members = $memberService->getMembers();
+        }
 
         return view('admin.users', compact('members'));
     }

--- a/apps/kita/app/Http/Requests/Member/SearchRequest.php
+++ b/apps/kita/app/Http/Requests/Member/SearchRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Member;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['string', 'nullable'],
+            'email' => ['string', 'nullable'],
+        ];
+    }
+}

--- a/apps/kita/app/Services/MemberService.php
+++ b/apps/kita/app/Services/MemberService.php
@@ -24,7 +24,7 @@ class MemberService{
      * @param array $keywords
      * @return array
      */
-    public function escapeKeyword(array $keywords)
+    private function escapeKeyword(array $keywords)
     {
         $escapedKeywords = [];
         foreach ($keywords as $field => $keyword) {
@@ -45,8 +45,10 @@ class MemberService{
 
         $membersPerPage = 10;
 
+        $escapedKeywords = $this->escapeKeyword($keywords);
+
         // 各フィールドに対して部分一致の検索条件を追加
-        foreach ($keywords as $field => $keyword) {
+        foreach ($escapedKeywords as $field => $keyword) {
             $query->where($field, 'LIKE', '%' . $keyword . '%');
         }
 

--- a/apps/kita/app/Services/MemberService.php
+++ b/apps/kita/app/Services/MemberService.php
@@ -18,4 +18,41 @@ class MemberService{
 
         return Member::orderBy('created_at', 'desc')->paginate($membersPerPage);
     }
+
+    /**
+     * 検索ワードそれぞれをescapeして、associative arrayで返す
+     * @param array $keywords
+     * @return array
+     */
+    public function escapeKeyword(array $keywords)
+    {
+        $escapedKeywords = [];
+        foreach ($keywords as $field => $keyword) {
+            $escapedKeywords[$field] = '%' . addcslashes($keyword, '%_\\') . '%';
+        }
+        return $escapedKeywords;
+    }
+
+
+    /**
+     * escape後の検索ワードで検索をかけ、合致したものを返す
+     * @param array $keywords
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function getSearchedMembers(array $keywords)
+    {
+        $query = Member::query();
+
+        $membersPerPage = 10;
+
+        // 各フィールドに対して部分一致の検索条件を追加
+        foreach ($keywords as $field => $keyword) {
+            $query->where($field, 'LIKE', '%' . $keyword . '%');
+        }
+
+        // 検索結果を取得
+        $results = $query->paginate($membersPerPage);
+
+        return $results;
+    }
 }

--- a/apps/kita/resources/views/admin/users.blade.php
+++ b/apps/kita/resources/views/admin/users.blade.php
@@ -8,17 +8,18 @@
             </div>
         </div>
 
+        {!! Form::open(['route' => 'member.index', 'method' => 'GET']) !!}
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">
                 <div class="border rounded p-3 bg-white">
                     <div class="row">
                         <div class="col-md-6 col-12">
                             <p class="mb-2">ユーザー名</p>
-                            {{ Form::text('name', null, ['class' => 'form-control', 'id' => 'name']) }}
+                            {!! Form::text('name', null, ['class' => 'form-control', 'id' => 'name']) !!}
                         </div>
                         <div class="col-md-6 col-12">
                             <p class="mb-2">メールアドレス</p>
-                            {{ Form::email('email', null, ['class' => 'form-control', 'id' => 'email']) }}
+                            {!! Form::email('email', null, ['class' => 'form-control', 'id' => 'email']) !!}
                         </div>
                     </div>
                 </div>
@@ -28,11 +29,11 @@
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">
                 <div class="border rounded p-3 text-center">
-                    {{ Form::submit('検索', ['class' => 'btn btn-primary']) }}
+                    {!! Form::submit('検索', ['class' => 'btn btn-primary']) !!}
                 </div>
             </div>
         </div>
-
+        {!! Form::close() !!}
         <div class="row">
             <nav aria-label="Page navigation example">
                 <ul class="pagination pt-3">


### PR DESCRIPTION
**概要**

user一覧表示

**詳細**

- ユーザー名、メールアドレスを受け取り、入力された値に合致するものを結果に出す。

- 未入力の場合、検索結果絞りをスキップすること。
 
- 全て未入力の場合、すべてのテーブル情報が表示されること。
 
- 一覧表示の中に検索処理を埋め込むこと。
 
- 念の為、エスケープも入れておくこと。

**チケット**

https://fullspeed.atlassian.net/browse/QKZA-53

**動画・画像**

成功

https://github.com/YoshikiWarashina/Kita/assets/129946179/4159bfcd-798c-46bd-b716-fae7ba965b60

未入力項目あり

https://github.com/YoshikiWarashina/Kita/assets/129946179/f319d2eb-b157-43b8-ba2e-fd76aef16b8b

全未入力(全て表示)

https://github.com/YoshikiWarashina/Kita/assets/129946179/c6baf4a6-ae40-45f6-8252-326fdf9d5612

