### PR TITLE
tag list

### DIFF
--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Services\TagService;
 use App\Http\Requests\Tag\CreateRequest;
 use App\Http\Requests\Tag\SearchRequest;
+use App\Http\Requests\Tag\UpdateRequest;
 class TagController extends Controller
 {
     /**
@@ -67,5 +68,27 @@ class TagController extends Controller
         $tag = $tagService->getTagById($id);
 
         return view('admin.article_tags.edit',compact('tag'));
+    }
+
+    /**
+     * タグをアップデートし、リダイレクト
+     *
+     * @param App\Services\TagService
+     * @param App\Http\Requests\Tag\UpdateRequest
+     * @param int $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function update(TagService $tagService, UpdateRequest $request, int $id)
+    {
+        $validatedData = $request->validated();
+
+        $tag = $tagService->updateTag($id, $validatedData);
+
+        $tagId = $tag->id;
+
+        return redirect('admin/article_tags/'.$tagId.'/edit')->with([
+            'message' => '更新処理が完了しました',
+            'tag' => $tag,
+        ]);
     }
 }

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Tag;
+
+use App\Http\Controllers\Controller;
+use App\Services\TagService;
+
+class TagController extends Controller
+{
+    /**
+     * タグ一覧表示
+     *
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function index(TagService $tagService)
+    {
+        $tags = $tagService->getTags();
+
+        return view('admin.article_tags', compact('tags'));
+    }
+}

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -46,7 +46,7 @@ class TagController extends Controller
     public function store(CreateRequest $request, TagService $tagService)
     {
         $validatedData = $request->validated();
-        $tag = $tagService->saveNewTag($validatedData);
+        $tag = $tagService->saveTag($validatedData);
 
         $tagId = $tag->id;
 

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -4,17 +4,24 @@ namespace App\Http\Controllers\Tag;
 
 use App\Http\Controllers\Controller;
 use App\Services\TagService;
-
+use App\Http\Requests\Tag\SearchRequest;
 class TagController extends Controller
 {
     /**
      * タグ一覧表示
-     *
+     * @param App\Services\TagService
+     * @param App\Http\Requests\Tag\SearchRequest
      * @return \Illuminate\Contracts\View\View
      */
-    public function index(TagService $tagService)
+    public function index(TagService $tagService, SearchRequest $request)
     {
-        $tags = $tagService->getTags();
+        $keyword = $request->input('name');
+
+        if(!empty($keyword)){
+            $tags = $tagService->getSearchedTags($keyword);
+        }else{
+            $tags = $tagService->getTags();
+        }
 
         return view('admin.article_tags', compact('tags'));
     }

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -39,6 +39,9 @@ class TagController extends Controller
     /**
      * タグ新規登録
      *
+     * @param App\Http\Requests\Tag\CreateRequest
+     * @param App\Services\TagService
+     * @return \Illuminate\Http\RedirectResponse
      */
     public function store(CreateRequest $request, TagService $tagService)
     {
@@ -53,6 +56,12 @@ class TagController extends Controller
         ]);
     }
 
+    /**
+     * タグ編集画面表示
+     * @param App\Services\TagService
+     * @param int $id
+     * @return \Illuminate\Contracts\View\View
+     */
     public function edit(TagService $tagService, int $id)
     {
         $tag = $tagService->getTagById($id);

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Tag;
 
 use App\Http\Controllers\Controller;
 use App\Services\TagService;
+use App\Http\Requests\Tag\CreateRequest;
 use App\Http\Requests\Tag\SearchRequest;
 class TagController extends Controller
 {
@@ -24,5 +25,38 @@ class TagController extends Controller
         }
 
         return view('admin.article_tags', compact('tags'));
+    }
+
+    /**
+     * タグ新規登録ページ表示
+     * @return \Illuminate\Contracts\View\View
+     */
+    public function create()
+    {
+        return view('admin.article_tags.create');
+    }
+
+    /**
+     * タグ新規登録
+     *
+     */
+    public function store(CreateRequest $request, TagService $tagService)
+    {
+        $validatedData = $request->validated();
+        $tag = $tagService->saveNewTag($validatedData);
+
+        $tagId = $tag->id;
+
+        return redirect('admin/article_tags/' . $tagId . '/edit')->with([
+            'message' => '登録処理が完了しました',
+            'tag' => $tag,
+        ]);
+    }
+
+    public function edit(TagService $tagService, int $id)
+    {
+        $tag = $tagService->getTagById($id);
+
+        return view('admin.article_tags.edit',compact('tag'));
     }
 }

--- a/apps/kita/app/Http/Requests/Tag/CreateRequest.php
+++ b/apps/kita/app/Http/Requests/Tag/CreateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'tag_name' => ['required', 'string', 'max:20', 'unique:article_tags,name'],
+        ];
+    }
+}

--- a/apps/kita/app/Http/Requests/Tag/SearchRequest.php
+++ b/apps/kita/app/Http/Requests/Tag/SearchRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SearchRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['string', 'nullable'],
+        ];
+    }
+}

--- a/apps/kita/app/Http/Requests/Tag/UpdateRequest.php
+++ b/apps/kita/app/Http/Requests/Tag/UpdateRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Tag;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateRequest extends FormRequest
 {
@@ -23,8 +24,10 @@ class UpdateRequest extends FormRequest
      */
     public function rules()
     {
+        $tagId = $this->route('id');
+
         return [
-            'tag_name' => ['required', 'string', 'max:20', 'unique:article_tags,name'],
+            'tag_name' => ['required', 'string', 'max:20', Rule::unique('article_tags', 'name')->ignore($tagId)],
         ];
     }
 }

--- a/apps/kita/app/Http/Requests/Tag/UpdateRequest.php
+++ b/apps/kita/app/Http/Requests/Tag/UpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Requests\Tag;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, mixed>
+     */
+    public function rules()
+    {
+        return [
+            'tag_name' => ['required', 'string', 'max:20', 'unique:article_tags,name'],
+        ];
+    }
+}

--- a/apps/kita/app/Models/Tag.php
+++ b/apps/kita/app/Models/Tag.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Tag extends Model
+{
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'name',
+    ];
+
+    /**
+     * The database table used by the model.
+     *
+     * @var string
+     */
+    protected $table = 'article_tags';
+}

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Tag;
+
+class TagService
+{
+    /**
+     * タグをページネーション込みで取得
+     *
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function getTags()
+    {
+        $tagsPerPage = 10;
+
+        return Tag::orderby('created_at')->paginate($tagsPerPage);
+    }
+}

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -47,4 +47,21 @@ class TagService
             ->orderBy('created_at', 'desc')
             ->paginate($tagsPerPage);
     }
+
+    public function saveNewTag(array $data)
+    {
+        $tag = new Tag();
+        $tag->fill([
+            'name' => $data['tag_name'],
+        ]);
+        $tag->save();
+        return $tag;
+    }
+
+    public function getTagById(int $id)
+    {
+        $tag = Tag::find($id);
+
+        return $tag;
+    }
 }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -44,7 +44,7 @@ class TagService
         $escapedKeyword = $this->escapeKeyword($keyword);
 
         return Tag::where('name', 'like', "%$escapedKeyword%")
-            ->orderBy('created_at', 'desc')
+            ->orderBy('updated_at', 'desc')
             ->paginate($tagsPerPage);
     }
 }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -15,7 +15,7 @@ class TagService
     {
         $tagsPerPage = 10;
 
-        return Tag::orderby('created_at')->paginate($tagsPerPage);
+        return Tag::orderby('updated_at', 'desc')->paginate($tagsPerPage);
     }
 
     /**
@@ -44,7 +44,7 @@ class TagService
         $escapedKeyword = $this->escapeKeyword($keyword);
 
         return Tag::where('name', 'like', "%$escapedKeyword%")
-            ->orderBy('created_at', 'desc')
+            ->orderBy('updated_at', 'desc')
             ->paginate($tagsPerPage);
     }
 
@@ -76,6 +76,23 @@ class TagService
     public function getTagById(int $id)
     {
         $tag = Tag::find($id);
+
+        return $tag;
+    }
+
+    /**
+     * タグをアップデート
+     *
+     * @param int $id
+     * @param array $data
+     * @return \App\Models\Tag
+     */
+    public function updateTag(int $id, array $data)
+    {
+        $tag = $this->getTagById($id);
+
+        $tag->name = $data['tag_name'];
+        $tag->save();
 
         return $tag;
     }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -48,16 +48,31 @@ class TagService
             ->paginate($tagsPerPage);
     }
 
+    /**
+     * タグをテーブルに保存
+     *
+     * @param array $data
+     * @return \App\Models\Tag
+     */
     public function saveNewTag(array $data)
     {
         $tag = new Tag();
+
         $tag->fill([
             'name' => $data['tag_name'],
         ]);
+
         $tag->save();
+
         return $tag;
     }
 
+    /**
+     * idをベースにタグを取得
+     *
+     * @param int $id
+     * @return \App\Models\Tag
+     */
     public function getTagById(int $id)
     {
         $tag = Tag::find($id);

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -54,7 +54,7 @@ class TagService
      * @param array $data
      * @return \App\Models\Tag
      */
-    public function saveNewTag(array $data)
+    public function saveTag(array $data)
     {
         $tag = new Tag();
 

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -15,6 +15,6 @@ class TagService
     {
         $tagsPerPage = 10;
 
-        return Tag::orderby('created_at')->paginate($tagsPerPage);
+        return Tag::orderby('updated_at', 'desc')->paginate($tagsPerPage);
     }
 }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -17,4 +17,34 @@ class TagService
 
         return Tag::orderby('created_at')->paginate($tagsPerPage);
     }
+
+    /**
+     * タグをページネーション込みで取得
+     *
+     * @param string $keyword
+     * @return string
+     */
+    private function escapeKeyword(string $keyword)
+    {
+        $escapedKeyword = '%' . addcslashes($keyword, '%_\\') . '%';
+
+        return $escapedKeyword;
+    }
+
+    /**
+     * タグの部分一致検索を行い、ページネーション込みで取得
+     *
+     * @param string $keyword
+     * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator
+     */
+    public function getSearchedTags(string $keyword)
+    {
+        $tagsPerPage = 10;
+
+        $escapedKeyword = $this->escapeKeyword($keyword);
+
+        return Tag::where('name', 'like', "%$escapedKeyword%")
+            ->orderBy('created_at', 'desc')
+            ->paginate($tagsPerPage);
+    }
 }

--- a/apps/kita/database/factories/TagFactory.php
+++ b/apps/kita/database/factories/TagFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    protected $model = Tag::class;
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->country,
+        ];
+    }
+}

--- a/apps/kita/database/factories/TagFactory.php
+++ b/apps/kita/database/factories/TagFactory.php
@@ -16,6 +16,7 @@ class TagFactory extends Factory
      * @return array<string, mixed>
      */
     protected $model = Tag::class;
+
     public function definition()
     {
         return [

--- a/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
+++ b/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
@@ -14,14 +14,12 @@ return new class extends Migration
     public function up()
     {
         Schema::create('members', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->rememberToken();
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->softDeletes()->nullable();
         });
     }
 

--- a/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
+++ b/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
@@ -18,8 +18,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
+            $table->timestamps();
         });
     }
 

--- a/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
+++ b/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
@@ -14,14 +14,14 @@ return new class extends Migration
     public function up()
     {
         Schema::create('admin_users', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->string('first_name');
             $table->string('last_name');
             $table->string('email')->unique();
             $table->string('password');
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->softDeletes()->nullable();
+            $table->timestamp('deleted_at')->nullable();
         });
     }
 

--- a/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
+++ b/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
@@ -19,8 +19,7 @@ return new class extends Migration
             $table->string('last_name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
+            $table->timestamps();
             $table->timestamp('deleted_at')->nullable();
         });
     }

--- a/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
+++ b/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
@@ -14,14 +14,14 @@ return new class extends Migration
     public function up()
     {
         Schema::create('articles', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->string('title');
             $table->mediumText('contents');
-            $table->unsignedBigInteger('member_id');
+            $table->unsignedInteger('member_id');
             $table->foreign('member_id')->references('id')->on('members');
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->softDeletes()->nullable();
+            $table->timestamp('deleted_at')->nullable();
         });
     }
 

--- a/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
+++ b/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
@@ -19,8 +19,7 @@ return new class extends Migration
             $table->mediumText('contents');
             $table->unsignedInteger('member_id');
             $table->foreign('member_id')->references('id')->on('members');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
+            $table->timestamps();
             $table->timestamp('deleted_at')->nullable();
         });
     }

--- a/apps/kita/database/migrations/2023_07_11_153412_create_article_comments_table.php
+++ b/apps/kita/database/migrations/2023_07_11_153412_create_article_comments_table.php
@@ -14,11 +14,11 @@ return new class extends Migration
     public function up()
     {
         Schema::create('article_comments', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->text('contents');
-            $table->unsignedBigInteger('member_id');
+            $table->unsignedInteger('member_id');
             $table->foreign('member_id')->references('id')->on('members');
-            $table->unsignedBigInteger('article_id');
+            $table->unsignedInteger('article_id');
             $table->foreign('article_id')->references('id')->on('articles');
             $table->timestamps();
         });

--- a/apps/kita/database/migrations/2023_07_28_181352_create_article_tags_table.php
+++ b/apps/kita/database/migrations/2023_07_28_181352_create_article_tags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_tags', function (Blueprint $table) {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_tags');
+    }
+};

--- a/apps/kita/database/seeders/DatabaseSeeder.php
+++ b/apps/kita/database/seeders/DatabaseSeeder.php
@@ -18,5 +18,6 @@ class DatabaseSeeder extends Seeder
         $this->call(MembersSeeder::class);
         $this->call(ArticlesSeeder::class);
         $this->call(CommentsSeeder::class);
+        $this->call(TagsSeeder::class);
     }
 }

--- a/apps/kita/database/seeders/TagsSeeder.php
+++ b/apps/kita/database/seeders/TagsSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Tag;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+
+class TagsSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        Tag::factory()->count(20)->create();
+    }
+}

--- a/apps/kita/lang/ja/validation.php
+++ b/apps/kita/lang/ja/validation.php
@@ -164,6 +164,7 @@ return [
         'contents' => '内容',
         'comment' => 'コメント',
         'name' => 'ユーザー名',
+        'tag_name' => 'タグ',
     ],
 
 ];

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -98,7 +98,9 @@
                                 <td>{{ $tag->name }}</td>
                                 <td>{{ $tag->created_at }}</td>
                                 <td class="text-center">
-                                    {{ Form::button('編集', ['class' => 'btn btn-primary']) }}
+                                    {!! Form::open(['route' => ['tag.edit', $tag->id],'method' => 'GET']) !!}
+                                    {!! Form::submit('編集', ['class' => 'btn btn-primary']) !!}
+                                    {!! Form::close() !!}
                                 </td>
                             </tr>
                             @endforeach

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -32,13 +32,46 @@
         {{ Form::close() }}
 
         <div class="row">
-            <nav aria-label="Page navigation example">
+            <nav aria-label="...">
                 <ul class="pagination pt-3">
-                    <li class="page-item"><a class="page-link" href="#">Previous</a></li>
-                    <li class="page-item"><a class="page-link" href="#">1</a></li>
-                    <li class="page-item"><a class="page-link" href="#">2</a></li>
-                    <li class="page-item"><a class="page-link" href="#">3</a></li>
-                    <li class="page-item"><a class="page-link" href="#">Next</a></li>
+                    @if ($tags->onFirstPage())
+                        <li class="page-item disabled">
+                            <span class="page-link" aria-label="前">
+                                Previous
+                            </span>
+                        </li>
+                    @else
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $tags->previousPageUrl() }}" aria-label="前">
+                                Previous
+                            </a>
+                        </li>
+                    @endif
+
+                    @php
+                        $startPage = max(1, $tags->currentPage() - 1);
+                        $endPage = min($startPage + 2, $tags->lastPage());
+                    @endphp
+
+                    @for ($page = $startPage; $page <= $endPage; $page++)
+                        <li class="page-item{{ $tags->currentPage() == $page ? ' active' : '' }}">
+                            <a class="page-link" href="{{ $tags->url($page) }}">{{ $page }}</a>
+                        </li>
+                    @endfor
+
+                    @if ($tags->hasMorePages())
+                        <li class="page-item">
+                            <a class="page-link" href="{{ $tags->nextPageUrl() }}" aria-label="次">
+                                Next
+                            </a>
+                        </li>
+                    @else
+                        <li class="page-item disabled">
+                            <span class="page-link" aria-label="次">
+                                Next
+                            </span>
+                        </li>
+                    @endif
                 </ul>
             </nav>
         </div>
@@ -57,14 +90,16 @@
                                 <th>登録日時</th>
                                 <th>レコード操作</th>
                             </tr>
+                            @foreach ($tags as $tag)
                             <tr>
-                                <td>デフォルトID</td>
-                                <td>デフォルトタグ名</td>
-                                <td>デフォルト登録日時</td>
+                                <td>{{ $tag->id }}</td>
+                                <td>{{ $tag->name }}</td>
+                                <td>{{ $tag->created_at }}</td>
                                 <td class="text-center">
                                     {{ Form::button('編集', ['class' => 'btn btn-primary']) }}
                                 </td>
                             </tr>
+                            @endforeach
                         </table>
                     </div>
                 </div>

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -79,7 +79,9 @@
             <div class="col-md-12 col-12 justify-content-center">
                 <div class="border rounded bg-white">
                     <div class="p-3">
-                        <button type="submit" class="btn btn-primary">新規登録</button>
+                        {!! Form::open(['route' => 'tag.create', 'method' => 'GET']) !!}
+                        {!! Form::submit('新規登録', ['class' => 'btn btn-primary']) !!}
+                        {!! Form::close() !!}
                     </div>
                     <div class="col-md-12 col-12 px-3">
                         <table class="table table-bordered table-hover">

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -8,14 +8,14 @@
             </div>
         </div>
 
-        {{ Form::open(['url' => 'admin/admin_users', 'method' => 'GET']) }}
+        {!! Form::open(['route' => 'tag.index', 'method' => 'GET']) !!}
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">
                 <div class="border rounded p-3 bg-white">
                     <div class="row">
                         <div class="col-md-12 col-12">
                             <p class="mb-2">タグ名</p>
-                            {{ Form::text('sirName', null, ['class' => 'form-control', 'id' => 'sirName']) }}
+                            {!! Form::text('name', null, ['class' => 'form-control', 'id' => 'name']) !!}
                         </div>
                     </div>
                 </div>
@@ -25,11 +25,11 @@
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">
                 <div class="border rounded p-3 text-center">
-                    {{ Form::submit('検索', ['class' => 'btn btn-primary']) }}
+                    {!! Form::submit('検索', ['class' => 'btn btn-primary']) !!}
                 </div>
             </div>
         </div>
-        {{ Form::close() }}
+        {!! Form::close() !!}
 
         <div class="row">
             <nav aria-label="...">

--- a/apps/kita/resources/views/admin/article_tags/create.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/create.blade.php
@@ -7,6 +7,18 @@
                 <h1>タグ管理 - 新規登録</h1>
             </div>
         </div>
+
+        @if($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
+
+        {!! Form::open(['route' => 'tag.store', 'method' => 'POST']) !!}
         <div class="row">
             <div class="col-md-9 col-12">
                 <div class="border rounded bg-white py-3">
@@ -15,7 +27,7 @@
                             <p class="mb-2 col-auto">タグ名</p>
                             <p class="mb-2 col-auto rounded bg-danger text-white">必須</p>
                         </div>
-                        {{ Form::text('sirName', null, ['class' => 'form-control', 'id' => 'sirName']) }}
+                        {{ Form::text('tag_name', null, ['class' => 'form-control', 'id' => 'tag_name']) }}
                     </div>
                 </div>
             </div>
@@ -27,5 +39,6 @@
                 </div>
             </div>
         </div>
+        {!! Form::close() !!}
     </div>
 @endsection

--- a/apps/kita/resources/views/admin/article_tags/edit.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/edit.blade.php
@@ -12,22 +12,22 @@
                 <div class="border rounded bg-white py-3">
                     <div class="col px-4 my-4">
                         <p class="mb-2">ID</p>
-                        {{ Form::text('sirName', null, ['class' => 'form-control', 'disabled', 'id' => 'sirName']) }}
+                        {{ Form::text('id', $tag->id, ['class' => 'form-control', 'disabled', 'id' => 'id']) }}
                     </div>
                     <div class="col px-4 my-4">
                         <div class="row">
                             <p class="mb-2 col-auto">タグ名</p>
                             <p class="mb-2 col-auto text-center rounded bg-danger text-white">必須</p>
                         </div>
-                        {{ Form::text('sirName', null, ['class' => 'form-control', 'id' => 'sirName']) }}
+                        {{ Form::text('tag_name', $tag->name, ['class' => 'form-control', 'id' => 'tag_name']) }}
                     </div>
                     <div class="col px-4 my-4">
                         <p class="mb-2">更新日時</p>
-                        {{ Form::text('sirName', null, ['class' => 'form-control', 'disabled', 'id' => 'sirName']) }}
+                        {{ Form::text('updated_at', $tag->updated_at, ['class' => 'form-control', 'disabled', 'id' => 'updated_at']) }}
                     </div>
                     <div class="col px-4 my-4">
                         <p class="mb-2">登録日時</p>
-                        {{ Form::text('sirName', null, ['class' => 'form-control', 'disabled', 'id' => 'sirName']) }}
+                        {{ Form::text('created_at', $tag->created_at, ['class' => 'form-control', 'disabled', 'id' => 'created_at']) }}
                     </div>
                 </div>
             </div>

--- a/apps/kita/resources/views/admin/article_tags/edit.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/edit.blade.php
@@ -7,46 +7,57 @@
                 <h1>タグ管理 - 更新</h1>
             </div>
         </div>
+        @if($errors->any())
+            <div class="alert alert-danger">
+                <ul>
+                    @foreach($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        @endif
         @if(session('message'))
             <div class="alert alert-success">
                 <h5 class="fw-bolder">Success!</h5>
                 {{ session('message') }}
             </div>
         @endif
+        {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
         <div class="row">
             <div class="col-md-9 col-12">
                 <div class="border rounded bg-white py-3">
                     <div class="col px-4 my-4">
                         <p class="mb-2">ID</p>
-                        {{ Form::text('id', $tag->id, ['class' => 'form-control', 'disabled', 'id' => 'id']) }}
+                        {!! Form::text('id', $tag->id, ['class' => 'form-control', 'disabled', 'id' => 'id']) !!}
                     </div>
                     <div class="col px-4 my-4">
                         <div class="row">
                             <p class="mb-2 col-auto">タグ名</p>
                             <p class="mb-2 col-auto text-center rounded bg-danger text-white">必須</p>
                         </div>
-                        {{ Form::text('tag_name', $tag->name, ['class' => 'form-control', 'id' => 'tag_name']) }}
+                        {!! Form::text('tag_name', $tag->name, ['class' => 'form-control', 'id' => 'tag_name']) !!}
                     </div>
                     <div class="col px-4 my-4">
                         <p class="mb-2">更新日時</p>
-                        {{ Form::text('updated_at', $tag->updated_at, ['class' => 'form-control', 'disabled', 'id' => 'updated_at']) }}
+                        {!! Form::text('updated_at', $tag->updated_at, ['class' => 'form-control', 'disabled', 'id' => 'updated_at']) !!}
                     </div>
                     <div class="col px-4 my-4">
                         <p class="mb-2">登録日時</p>
-                        {{ Form::text('created_at', $tag->created_at, ['class' => 'form-control', 'disabled', 'id' => 'created_at']) }}
+                        {!! Form::text('created_at', $tag->created_at, ['class' => 'form-control', 'disabled', 'id' => 'created_at']) !!}
                     </div>
                 </div>
             </div>
             <div class="col-md-3 col-12">
                 <div class="border rounded bg-white py-3 px-3">
                     <div class="col-md-12 col-12 text-center py-2">
-                        {{ Form::submit('更新する', ['class' => 'btn btn-primary w-100']) }}
+                        {!! Form::submit('更新する', ['class' => 'btn btn-primary w-100']) !!}
                     </div>
                     <div class="col-md-12 col-12 text-center py-2">
-                        {{ Form::submit('削除する', ['class' => 'btn btn-danger w-100']) }}
+                        {!! Form::submit('削除する', ['class' => 'btn btn-danger w-100']) !!}
                     </div>
                 </div>
             </div>
         </div>
+        {!! Form::close() !!}
     </div>
 @endsection

--- a/apps/kita/resources/views/admin/article_tags/edit.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/edit.blade.php
@@ -7,6 +7,12 @@
                 <h1>タグ管理 - 更新</h1>
             </div>
         </div>
+        @if(session('message'))
+            <div class="alert alert-success">
+                <h5 class="fw-bolder">Success!</h5>
+                {{ session('message') }}
+            </div>
+        @endif
         <div class="row">
             <div class="col-md-9 col-12">
                 <div class="border rounded bg-white py-3">

--- a/apps/kita/resources/views/admin/header.blade.php
+++ b/apps/kita/resources/views/admin/header.blade.php
@@ -21,7 +21,7 @@
                 <div class="collapse navbar-collapse" id="navbarSupportedContent">
                     <ul class="navbar-nav me-auto mb-2 mx-4 mb-lg-0">
                         <li class="nav-item">
-                            <a class="nav-link active text-light mx-3" aria-current="page" href="#">管理者管理</a>
+                            <a class="nav-link text-light mx-3" href="{{ route('admin_users.index') }}">管理者管理</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-light mx-3" href="{{ route('member.index') }}">会員管理</a>

--- a/apps/kita/resources/views/admin/header.blade.php
+++ b/apps/kita/resources/views/admin/header.blade.php
@@ -27,7 +27,7 @@
                             <a class="nav-link text-light mx-3" href="{{ route('member.index') }}">会員管理</a>
                         </li>
                         <li class="nav-item dropdown">
-                            <a class="nav-link text-light mx-3" href="#">タグ管理</a>
+                            <a class="nav-link text-light mx-3" href="{{ route('tag.index') }}">タグ管理</a>
                         </li>
                     </ul>
                     <li class="d-flex ml-auto mx-3">

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -42,6 +42,9 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
     Route::put('/admin_users/{id}', [AdminController::class, 'update'])->name('admin_users.update');
     Route::get('/users',[MemberController::class, 'index'])->name('member.index');
     Route::get('/article_tags',[TagController::class, 'index'])->name('tag.index');
+    Route::get('/article_tags/create',[TagController::class, 'create'])->name('tag.create');
+    Route::post('/article_tags',[TagController::class, 'store'])->name('tag.store');
+    Route::get('/article_tags/{id}/edit',[TagController::class, 'edit'])->name('tag.edit');
 });
 
 

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -45,6 +45,7 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
     Route::get('/article_tags/create',[TagController::class, 'create'])->name('tag.create');
     Route::post('/article_tags',[TagController::class, 'store'])->name('tag.store');
     Route::get('/article_tags/{id}/edit',[TagController::class, 'edit'])->name('tag.edit');
+    Route::put('/article_tags/{id}/edit', [TagController::class, 'update'])->name('tag.update');
 });
 
 

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\Comment\CommentController;
 use App\Http\Controllers\Member\MemberController;
 use App\Http\Controllers\Auth\ProfileController;
 use App\Http\Controllers\Auth\PasswordController;
+use App\Http\Controllers\Tag\TagController;
 
 /*
 |--------------------------------------------------------------------------
@@ -40,6 +41,7 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
     Route::delete('/admin_users/{id}', [AdminController::class, 'destroy'])->name('admin_users.destroy');
     Route::put('/admin_users/{id}', [AdminController::class, 'update'])->name('admin_users.update');
     Route::get('/users',[MemberController::class, 'index'])->name('member.index');
+    Route::get('/article_tags',[TagController::class, 'index'])->name('tag.index');
 });
 
 


### PR DESCRIPTION
**概要**

タグ一覧表示

**詳細**

- データベースにあるタグ一覧をページネーション込みで表示すること(1ページ10個)
- テストデータは、こんなテストデータを代入できるんだ程度に国名(タグっぽい)を使ってみた
- ヘッダーのタグ管理をクリックすると、タグ一覧ページに飛べるようになっていること
- 登録日時の降順で並ぶこと。

**チケット**

https://fullspeed.atlassian.net/browse/QKZA-54

**動画・画像**

https://github.com/YoshikiWarashina/Kita/assets/129946179/20d0dcfb-7caf-423b-a86a-ccc5d3564664

