### PR TITLE
migration fix

### DIFF
--- a/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
+++ b/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
@@ -14,14 +14,12 @@ return new class extends Migration
     public function up()
     {
         Schema::create('members', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->rememberToken();
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->softDeletes()->nullable();
         });
     }
 

--- a/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
+++ b/apps/kita/database/migrations/2023_06_28_055142_create_members_table.php
@@ -18,8 +18,7 @@ return new class extends Migration
             $table->string('name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
+            $table->timestamps();
         });
     }
 

--- a/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
+++ b/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
@@ -14,14 +14,14 @@ return new class extends Migration
     public function up()
     {
         Schema::create('admin_users', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->string('first_name');
             $table->string('last_name');
             $table->string('email')->unique();
             $table->string('password');
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->softDeletes()->nullable();
+            $table->timestamp('deleted_at')->nullable();
         });
     }
 

--- a/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
+++ b/apps/kita/database/migrations/2023_06_29_053420_create_admin_users_table.php
@@ -19,8 +19,7 @@ return new class extends Migration
             $table->string('last_name');
             $table->string('email')->unique();
             $table->string('password');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
+            $table->timestamps();
             $table->timestamp('deleted_at')->nullable();
         });
     }

--- a/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
+++ b/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
@@ -14,14 +14,14 @@ return new class extends Migration
     public function up()
     {
         Schema::create('articles', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->string('title');
             $table->mediumText('contents');
-            $table->unsignedBigInteger('member_id');
+            $table->unsignedInteger('member_id');
             $table->foreign('member_id')->references('id')->on('members');
             $table->timestamp('created_at')->nullable();
             $table->timestamp('updated_at')->nullable();
-            $table->softDeletes()->nullable();
+            $table->timestamp('deleted_at')->nullable();
         });
     }
 

--- a/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
+++ b/apps/kita/database/migrations/2023_07_04_180140_create_articles_table.php.php
@@ -19,8 +19,7 @@ return new class extends Migration
             $table->mediumText('contents');
             $table->unsignedInteger('member_id');
             $table->foreign('member_id')->references('id')->on('members');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
+            $table->timestamps();
             $table->timestamp('deleted_at')->nullable();
         });
     }

--- a/apps/kita/database/migrations/2023_07_11_153412_create_article_comments_table.php
+++ b/apps/kita/database/migrations/2023_07_11_153412_create_article_comments_table.php
@@ -14,11 +14,11 @@ return new class extends Migration
     public function up()
     {
         Schema::create('article_comments', function (Blueprint $table) {
-            $table->id();
+            $table->unsignedInteger('id')->autoIncrement();
             $table->text('contents');
-            $table->unsignedBigInteger('member_id');
+            $table->unsignedInteger('member_id');
             $table->foreign('member_id')->references('id')->on('members');
-            $table->unsignedBigInteger('article_id');
+            $table->unsignedInteger('article_id');
             $table->foreign('article_id')->references('id')->on('articles');
             $table->timestamps();
         });


### PR DESCRIPTION
**概要**

マイグレーションの修正

**詳細**

ほぼ全てのテーブルで$table->id()と書いていたが、これはunsigned big intを表すため、
実際のテーブル定義とは異なっていた。

そこで、$table->unsignedInteger('id')->autoIncrement();とすることでunsigned intとなり、定義にそう

あとはdelete_atがsoftDeletesになっていたが、modelでuse softDeletesすれば適用できるため
マイグレーション側ではtimestampに直した。


**チケット**
https://fullspeed.atlassian.net/browse/QKZA-58

**テーブル定義**

https://docs.google.com/spreadsheets/d/1rOaDBnJoagWrmqYwFD0Ak6C720BSv3y27h3AbfAj3bQ/edit#gid=515443895