### PR TITLE
article post with tag

### DIFF
--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -27,7 +27,6 @@ class ArticleController extends Controller
             $articles = $articleService->getSearchedArticles($search);
         }else{
             $articles = $articleService->getArticles();
-
         }
 
         return view('articles.articles', compact('articles'));

--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -5,9 +5,8 @@ namespace App\Http\Controllers\Article;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Article\SearchRequest;
 use App\Http\Requests\Article\UpdateRequest;
-use App\Http\Requests\Article\DeleteRequest;
 use App\Services\ArticleService;
-use Illuminate\Http\Request;
+use App\Services\TagService;
 use App\Http\Requests\Article\CreateRequest;
 use Illuminate\Support\Facades\Auth;
 
@@ -27,17 +26,21 @@ class ArticleController extends Controller
     }
 
     /**
-     * Show the form for creating a new resource.
+     * タグとともに新規投稿ページを表示
      *
+     * @param \App\Services\TagService
      * @return \Illuminate\Contracts\View\View
      */
-    public function create()
+    public function create(TagService $tagService)
     {
-        return view('articles.create');
+        $tags = $tagService->getTagsForArticle();
+
+        return view('articles.create', compact('tags'));
     }
 
+
     /**
-     * Store a newly created resource in storage.
+     * 記事をテーブルに保存
      *
      * @param  \App\Services\ArticleService  $articleService
      * @param  App\Http\Requests\Article\CreateRequest $request
@@ -49,7 +52,11 @@ class ArticleController extends Controller
         $article = $articleService->saveNewArticle($validatedData);
 
         $articleId = $article->id;
-        return redirect('articles/'.$articleId.'/edit')->with('message', '記事投稿が完了しました')->with('article', $article);
+
+        return redirect('articles/'.$articleId.'/edit')->with([
+            'message' => '記事投稿が完了しました',
+            'article' => $article
+        ]);
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -13,14 +13,22 @@ use Illuminate\Support\Facades\Auth;
 class ArticleController extends Controller
 {
     /**
-     * 記事一覧表示
+     * 記事一覧表示/検索
      *
+     * @param App\Services\ArticleService $articleService
+     * @param App\Http\Requests\Article\SearchRequest $request
      * @return \Illuminate\Contracts\View\View
      */
-    public function index()
+    public function index(ArticleService $articleService, SearchRequest $request)
     {
-        $articleService = new ArticleService();
-        $articles = $articleService->getArticles();
+        $search = $request->input('search');
+
+        if (!empty($search)) {
+            $articles = $articleService->getSearchedArticles($search);
+        }else{
+            $articles = $articleService->getArticles();
+
+        }
 
         return view('articles.articles', compact('articles'));
     }
@@ -127,21 +135,4 @@ class ArticleController extends Controller
         return redirect('articles')->with('message', '記事を削除しました');
     }
 
-    /**
-     * 検索用に入力された値を受け取り、エスケープさせ、返ってきた検索結果をviewに渡す
-     *
-     * @param  ArticleService  $articleService
-     * @param  SearchRequest  $searchRequest
-     * @return \Illuminate\Contracts\View\View
-     */
-    public function search(ArticleService $articleService, SearchRequest $searchRequest)
-    {
-        $search = $searchRequest->input('search');
-
-        $escapedKeyword = '%' . addcslashes($search, '%_\\') . '%';
-
-        $articles = $articleService->getSearchedArticles($escapedKeyword);
-
-        return view('articles.articles', compact('articles'));
-    }
 }

--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -98,7 +98,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * 記事の更新
      *
      * @param  \App\Services\ArticleService  $articleService
      * @param  \App\Http\Requests\Article\UpdateRequest $request
@@ -116,7 +116,11 @@ class ArticleController extends Controller
         $article = $articleService->updateArticle($id, $validatedData);
 
         $articleId = $article->id;
-        return redirect('articles/'.$articleId.'/edit')->with('message', '記事編集が完了しました')->with('article', $article);
+
+        return redirect('articles/'.$articleId.'/edit')->with([
+            'message'=> '記事編集が完了しました',
+            'article'=> $article
+        ]);
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -82,18 +82,19 @@ class ArticleController extends Controller
     }
 
     /**
+     * 記事編集ページ表示
      *
-     * @param  \App\Services\ArticleService  $articleService
+     * @param  \App\Services\ArticleService $articleService
+     * @param  \App\Services\TagService $tagService
      * @param  int  $id
      * @return \Illuminate\Contracts\View\View
-     * Show the form for editing the specified resource.
-     *
      */
-    public function edit(ArticleService $articleService, int $id)
+    public function edit(ArticleService $articleService, TagService $tagService, int $id)
     {
         $article = $articleService->getArticleById($id);
+        $tags = $tagService->getTagsForArticle();
 
-        return view('articles.edit', ['article' => $article]);
+        return view('articles.edit', compact('article', 'tags'));
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -91,4 +91,17 @@ class TagController extends Controller
             'tag' => $tag,
         ]);
     }
+
+    /**
+     * タグ削除
+     * @param App\Services\TagService
+     * @param int $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(TagService $tagService, int $id)
+    {
+        $tagService->deleteTag($id);
+
+        return redirect('admin/article_tags')->with('message', 'タグを削除しました');
+    }
 }

--- a/apps/kita/app/Http/Requests/Article/CreateRequest.php
+++ b/apps/kita/app/Http/Requests/Article/CreateRequest.php
@@ -25,6 +25,7 @@ class CreateRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:20'],
+            'tags' => ['array', 'max:5', 'nullable'],
             'contents' =>['required', 'string', 'max:400'],
         ];
     }

--- a/apps/kita/app/Http/Requests/Article/UpdateRequest.php
+++ b/apps/kita/app/Http/Requests/Article/UpdateRequest.php
@@ -25,6 +25,7 @@ class UpdateRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:20'],
+            'tags' => ['array', 'max:5', 'nullable', 'distinct'],
             'contents' =>['required', 'string', 'max:400'],
         ];
     }

--- a/apps/kita/app/Models/Article.php
+++ b/apps/kita/app/Models/Article.php
@@ -60,6 +60,6 @@ class Article extends Model
      */
     public function tags()
     {
-        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id');
+        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id')->withTimestamps();
     }
 }

--- a/apps/kita/app/Models/Article.php
+++ b/apps/kita/app/Models/Article.php
@@ -12,6 +12,8 @@ class Article extends Model
     use HasFactory;
     use SoftDeletes;
 
+    protected $primaryKey = 'id';
+
     /**
      * The attributes that are mass assignable.
      *
@@ -60,6 +62,6 @@ class Article extends Model
      */
     public function tags()
     {
-        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id');
+        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id')->withTimestamps();
     }
 }

--- a/apps/kita/app/Models/Article.php
+++ b/apps/kita/app/Models/Article.php
@@ -52,4 +52,14 @@ class Article extends Model
     {
         return $this->hasMany(Comment::class);
     }
+
+    /**
+     * 記事が紐つけられるタグの取得
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id');
+    }
 }

--- a/apps/kita/app/Models/Tag.php
+++ b/apps/kita/app/Models/Tag.php
@@ -9,6 +9,7 @@ class Tag extends Model
 {
     use HasFactory;
 
+    protected $primaryKey = 'id';
     /**
      * The attributes that are mass assignable.
      *

--- a/apps/kita/app/Models/Tag.php
+++ b/apps/kita/app/Models/Tag.php
@@ -24,4 +24,14 @@ class Tag extends Model
      * @var string
      */
     protected $table = 'article_tags';
+
+    /**
+     * タグに関連付けられた記事の取得
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany
+     */
+    public function articles()
+    {
+        return $this->belongsToMany(Article::class, 'article_article_tag', 'article_tag_id', 'article_id');
+    }
 }

--- a/apps/kita/app/Models/Tag.php
+++ b/apps/kita/app/Models/Tag.php
@@ -32,6 +32,6 @@ class Tag extends Model
      */
     public function articles()
     {
-        return $this->belongsToMany(Article::class, 'article_article_tag', 'article_tag_id', 'article_id');
+        return $this->belongsToMany(Article::class, 'article_article_tag', 'article_tag_id', 'article_id')->withTimestamps();
     }
 }

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -131,24 +131,19 @@ class ArticleService{
             'contents' => $data['contents'],
         ]);
 
-        // タグの関連付け(updated_atを更新するためdetachして再度attachする)
+        $syncData = [];
+
+        // タグの関連付け(if文: タグあり、それ以外: タグなし)
         if (isset($data['tags']) && is_array($data['tags'])) {
             $tags = $data['tags'];
 
-            $timestamp = date('Y-m-d H:i:s'); // 現在の日時を取得
-
-            // 一旦タグの関連付けを削除
-            $article->tags()->detach();
-
-            // 更新したタグを関連付け
+            // タグにcreated_at updated_atを追加
             foreach ($tags as $tag) {
-                $pivotData = [
-                    'created_at' => $timestamp,
-                    'updated_at' => $timestamp,
-                ];
-                $article->tags()->attach($tag, $pivotData); // 中間テーブルにデータを追加
+                $syncData[$tag] = ['created_at' => now(), 'updated_at' => now()];
             }
         }
+        $article->tags()->sync($syncData);
+
         return $article;
     }
 

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -38,7 +38,7 @@ class ArticleService{
     }
 
     /**
-     * 新しい記事を保存
+     * 新しい記事を保存したあと、タグを関連付ける
      *
      * @param array $data
      * @return Article
@@ -54,6 +54,11 @@ class ArticleService{
         ]);
 
         $article->save();
+
+        //タグの関連付け
+        if (isset($data['tags']) && is_array($data['tags'])) {
+            $article->tags()->attach($data['tags']);
+        }
 
         return $article;
     }

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -60,12 +60,11 @@ class ArticleService{
             $tags = $data['tags'];
 
             foreach ($tags as $tag) {
-                $timestamp = date('Y-m-d H:i:s'); // 現在の日時を取得
                 $pivotData = [
-                    'created_at' => $timestamp,
-                    'updated_at' => $timestamp,
+                    'created_at' => now(),
+                    'updated_at' => now(),
                 ];
-                $article->tags()->attach($tag, $pivotData); // 中間テーブルにデータを追加
+                $article->tags()->attach($tag, $pivotData);
             }
         }
 

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -2,11 +2,11 @@
 
 namespace App\Services;
 
-use App\Models\Admin;
 use App\Models\Article;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Exception;
+
 class ArticleService{
 
     /**
@@ -121,30 +121,37 @@ class ArticleService{
      * @param int $articleId;
      * @param array $data
      * @return Article
+     * @@throws Exception
      */
     public function updateArticle(int $articleId, array $data)
     {
-        $article = $this->getArticleById($articleId);
+        DB::beginTransaction();
 
-        $article->update([
-            'title' => $data['title'],
-            'contents' => $data['contents'],
-        ]);
+        try {
+            $article = $this->getArticleById($articleId);
 
-        $syncData = [];
+            $article->update([
+                'title' => $data['title'],
+                'contents' => $data['contents'],
+            ]);
 
-        // タグの関連付け(if文: タグあり、それ以外: タグなし)
-        if (isset($data['tags']) && is_array($data['tags'])) {
-            $tags = $data['tags'];
+            $tags = [];
 
-            // タグにcreated_at updated_atを追加
-            foreach ($tags as $tag) {
-                $syncData[$tag] = ['created_at' => now(), 'updated_at' => now()];
+            // タグの関連付け(if文: タグあり、それ以外: タグなし)
+            if (isset($data['tags']) && is_array($data['tags'])) {
+                $tags = $data['tags'];
             }
-        }
-        $article->tags()->sync($syncData);
 
-        return $article;
+            $article->tags()->sync($tags);
+            DB::commit();
+
+            return $article;
+
+        } catch (\Exception $e) {
+            // トランザクションのロールバック
+            DB::rollback();
+            throw $e;
+        }
     }
 
     /**

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -126,12 +126,29 @@ class ArticleService{
     {
         $article = $this->getArticleById($articleId);
 
-
         $article->update([
             'title' => $data['title'],
             'contents' => $data['contents'],
         ]);
 
+        // タグの関連付け(updated_atを更新するためdetachして再度attachする)
+        if (isset($data['tags']) && is_array($data['tags'])) {
+            $tags = $data['tags'];
+
+            $timestamp = date('Y-m-d H:i:s'); // 現在の日時を取得
+
+            // 一旦タグの関連付けを削除
+            $article->tags()->detach();
+
+            // 更新したタグを関連付け
+            foreach ($tags as $tag) {
+                $pivotData = [
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
+                ];
+                $article->tags()->attach($tag, $pivotData); // 中間テーブルにデータを追加
+            }
+        }
         return $article;
     }
 

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -55,9 +55,18 @@ class ArticleService{
 
         $article->save();
 
-        //タグの関連付け
+        //タグの関連付け(created_at updated_at込み)
         if (isset($data['tags']) && is_array($data['tags'])) {
-            $article->tags()->attach($data['tags']);
+            $tags = $data['tags'];
+
+            foreach ($tags as $tag) {
+                $timestamp = date('Y-m-d H:i:s'); // 現在の日時を取得
+                $pivotData = [
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
+                ];
+                $article->tags()->attach($tag, $pivotData); // 中間テーブルにデータを追加
+            }
         }
 
         return $article;

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -18,7 +18,20 @@ class ArticleService{
     {
         $articlesPerPage = 10;
 
-        return Article::orderBy('updated_at', 'asc')->paginate($articlesPerPage);
+        return Article::orderBy('updated_at', 'desc')->paginate($articlesPerPage);
+    }
+
+    /**
+     * 検索ワードをエスケープ
+     *
+     * @param string $keyword
+     * @return string
+     */
+    private function escapeKeyword(string $keyword)
+    {
+        $escapedKeyword = '%' . addcslashes($keyword, '%_\\') . '%';
+
+        return $escapedKeyword;
     }
 
     /**
@@ -31,8 +44,10 @@ class ArticleService{
     {
         $articlesPerPage = 10;
 
-        return Article::where('title', 'like', "%$keyword%")
-            ->orWhere('contents', 'like', "%$keyword%")
+        $escapedKeyword = $this->escapeKeyword($keyword);
+
+        return Article::where('title', 'like', "%$escapedKeyword%")
+            ->orWhere('contents', 'like', "%$escapedKeyword%")
             ->orderBy('updated_at', 'desc')
             ->paginate($articlesPerPage);
     }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -106,4 +106,19 @@ class TagService
 
         return $tag;
     }
+
+
+    /**
+     * idをベースにタグを取得し、
+     * 記事との中間テーブルレコードを削除、かつタグ自体も削除
+     *
+     * @param int $id
+     * @return void
+     */
+    public function deleteTag(int $id)
+    {
+        $tag = $this->getTagById($id);
+        $tag->articles()->detach();
+        $tag->delete();
+    }
 }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -7,6 +7,16 @@ use App\Models\Tag;
 class TagService
 {
     /**
+     * 記事投稿する際に表示するタグ(アルファベット順)
+     *
+     *@return  App\Models\Tag
+     */
+    public function getTagsForArticle()
+    {
+        return Tag::orderBy('name', 'asc')->get();
+    }
+
+    /**
      * タグをページネーション込みで取得
      *
      * @return \Illuminate\Contracts\Pagination\LengthAwarePaginator

--- a/apps/kita/database/factories/TagFactory.php
+++ b/apps/kita/database/factories/TagFactory.php
@@ -19,7 +19,7 @@ class TagFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->country,
+            'name' => $this->faker->unique()->country,
         ];
     }
 }

--- a/apps/kita/database/migrations/2023_08_01_152511_create_article_article_tag_table.php
+++ b/apps/kita/database/migrations/2023_08_01_152511_create_article_article_tag_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('article_article_tag', function (Blueprint $table) {
+            $table->unsignedInteger('id')->autoIncrement();
+            $table->unsignedInteger('article_id');
+            $table->foreign('article_id')->references('id')->on('articles');
+            $table->unsignedInteger('article_tag_id');
+            $table->foreign('article_tag_id')->references('id')->on('article_tags');
+            $table->timestamps();
+
+            $table->unique(['article_id', 'article_tag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('article_article_tag');
+    }
+};

--- a/apps/kita/database/migrations/2023_08_01_152511_create_article_article_tag_table.php
+++ b/apps/kita/database/migrations/2023_08_01_152511_create_article_article_tag_table.php
@@ -16,9 +16,9 @@ return new class extends Migration
         Schema::create('article_article_tag', function (Blueprint $table) {
             $table->unsignedInteger('id')->autoIncrement();
             $table->unsignedInteger('article_id');
-            $table->foreign('article_id')->references('id')->on('articles');
+            $table->foreign('article_id')->references('id')->on('articles')->onDelete('cascade');
             $table->unsignedInteger('article_tag_id');
-            $table->foreign('article_tag_id')->references('id')->on('article_tags');
+            $table->foreign('article_tag_id')->references('id')->on('article_tags')->onDelete('cascade');
             $table->timestamps();
 
             $table->unique(['article_id', 'article_tag_id']);

--- a/apps/kita/database/seeders/ArticlesSeeder.php
+++ b/apps/kita/database/seeders/ArticlesSeeder.php
@@ -4,7 +4,6 @@ namespace Database\Seeders;
 
 use App\Models\Article;
 use App\Models\Tag;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class ArticlesSeeder extends Seeder
@@ -14,14 +13,13 @@ class ArticlesSeeder extends Seeder
      *
      * @return void
      */
+
     public function run()
     {
         $tags = Tag::all();
 
-        $articles = Article::factory()->count(40)->create();
-
         // 各記事に3つのタグをランダムに紐付ける
-        $articles->each(function ($article) use ($tags) {
+        Article::factory()->count(40)->create()->each(function ($article) use ($tags) {
             $article->tags()->attach($tags->random(3), ['created_at' => now(), 'updated_at' => now()]);
         });
     }

--- a/apps/kita/database/seeders/ArticlesSeeder.php
+++ b/apps/kita/database/seeders/ArticlesSeeder.php
@@ -22,7 +22,7 @@ class ArticlesSeeder extends Seeder
 
         // 各記事に3つのタグをランダムに紐付ける
         $articles->each(function ($article) use ($tags) {
-            $article->tags()->attach($tags->random(3));
+            $article->tags()->attach($tags->random(3), ['created_at' => now(), 'updated_at' => now()]);
         });
     }
 }

--- a/apps/kita/database/seeders/ArticlesSeeder.php
+++ b/apps/kita/database/seeders/ArticlesSeeder.php
@@ -3,6 +3,7 @@
 namespace Database\Seeders;
 
 use App\Models\Article;
+use App\Models\Tag;
 use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
@@ -15,6 +16,13 @@ class ArticlesSeeder extends Seeder
      */
     public function run()
     {
-        Article::factory()->count(40)->create();
+        $tags = Tag::all();
+
+        $articles = Article::factory()->count(40)->create();
+
+        // 各記事に3つのタグをランダムに紐付ける
+        $articles->each(function ($article) use ($tags) {
+            $article->tags()->attach($tags->random(3));
+        });
     }
 }

--- a/apps/kita/database/seeders/DatabaseSeeder.php
+++ b/apps/kita/database/seeders/DatabaseSeeder.php
@@ -16,8 +16,8 @@ class DatabaseSeeder extends Seeder
     {
         $this->call(AdminSeeder::class);
         $this->call(MembersSeeder::class);
+        $this->call(TagsSeeder::class);
         $this->call(ArticlesSeeder::class);
         $this->call(CommentsSeeder::class);
-        $this->call(TagsSeeder::class);
     }
 }

--- a/apps/kita/lang/ja/validation.php
+++ b/apps/kita/lang/ja/validation.php
@@ -83,7 +83,7 @@ return [
         'numeric' => ':attributeには、:max以下の数字を指定してください。',
         'file' => ':attributeには、:max kB以下のファイルを指定してください。',
         'string' => ':attributeは、:max文字以下で指定してください。',
-        'array' => ':attributeは:max個以下指定してください。',
+        'array' => ':attributeは:max個以下で指定してください。',
     ],
     'mimes' => ':attributeには:valuesタイプのファイルを指定してください。',
     'mimetypes' => ':attributeには:valuesタイプのファイルを指定してください。',
@@ -165,6 +165,7 @@ return [
         'comment' => 'コメント',
         'name' => 'ユーザー名',
         'tag_name' => 'タグ',
+        'tags' => 'タグ',
     ],
 
 ];

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -8,6 +8,13 @@
             </div>
         </div>
 
+        @if(session('message'))
+            <div class="alert alert-success">
+                <h5 class="fw-bolder">Success!</h5>
+                {{ session('message') }}
+            </div>
+        @endif
+
         {!! Form::open(['route' => 'tag.index', 'method' => 'GET']) !!}
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">

--- a/apps/kita/resources/views/admin/article_tags/edit.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/edit.blade.php
@@ -22,9 +22,9 @@
                 {{ session('message') }}
             </div>
         @endif
-        {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
         <div class="row">
             <div class="col-md-9 col-12">
+                {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
                 <div class="border rounded bg-white py-3">
                     <div class="col px-4 my-4">
                         <p class="mb-2">ID</p>
@@ -51,13 +51,15 @@
                 <div class="border rounded bg-white py-3 px-3">
                     <div class="col-md-12 col-12 text-center py-2">
                         {!! Form::submit('更新する', ['class' => 'btn btn-primary w-100']) !!}
+                        {!! Form::close() !!}
                     </div>
                     <div class="col-md-12 col-12 text-center py-2">
+                        {!! Form::open(['route' => ['tag.destroy', $tag->id],'method' => 'DELETE', 'onsubmit' => "return confirm('一度削除すると元に戻せません。よろしいですか？');"]) !!}
                         {!! Form::submit('削除する', ['class' => 'btn btn-danger w-100']) !!}
+                        {!! Form::close() !!}
                     </div>
                 </div>
             </div>
         </div>
-        {!! Form::close() !!}
     </div>
 @endsection

--- a/apps/kita/resources/views/articles/articles.blade.php
+++ b/apps/kita/resources/views/articles/articles.blade.php
@@ -27,15 +27,11 @@
                                 <h3 class="text-secondary">{{ $article->title }}</h3>
                             </a>
                             <div class="row mb-2 border-bottom border-dark">
+                                @foreach ($article->tags as $tag)
                                 <div class="col-auto">
-                                    <p class="text-white bg-primary px-2 rounded">javascript</p>
+                                    <p class="text-white bg-primary px-2 rounded">{{ $tag->name }}</p>
                                 </div>
-                                <div class="col-auto">
-                                    <p class="text-white bg-primary px-2 rounded">Vue</p>
-                                </div>
-                                <div class="col-auto">
-                                    <p class="text-white bg-primary px-2 rounded">Vite</p>
-                                </div>
+                                @endforeach
                             </div>
                         @endforeach
                     </div>
@@ -62,7 +58,7 @@
 
                             @for ($page = $startPage; $page <= $endPage; $page++)
                                 <li class="page-item{{ $articles->currentPage() == $page ? ' active' : '' }}">
-                                    <a class="page-link border-success text-success{{ $articles->currentPage() == $page ? ' bg-success' : '' }}" href="{{ $articles->url($page) }}">{{ $page }}</a>
+                                    <a class="page-link border-success text-success{{ $articles->currentPage() == $page ? ' bg-success text-white' : '' }}" href="{{ $articles->url($page) }}">{{ $page }}</a>
                                 </li>
                             @endfor
 

--- a/apps/kita/resources/views/articles/create.blade.php
+++ b/apps/kita/resources/views/articles/create.blade.php
@@ -25,11 +25,10 @@
                         <div class="pb-0">
                             <p>タグ</p>
                         </div>
-                        <select class="form-select border-success" size="3" aria-label="size 3 select example">
-                            <option value="1">PHP</option>
-                            <option value="2">Java</option>
-                            <option value="3">javascript</option>
-                            <option value="4">Ruby</option>
+                        <select class="form-select border-success" size="5" aria-label="タグ選択" name="tags[]" multiple>
+                            @foreach($tags as $tag)
+                                <option value="{{ $tag->id }}">{{ $tag->name }}</option>
+                            @endforeach
                         </select>
                     </div>
                     <div class="px-3 py-4">

--- a/apps/kita/resources/views/articles/detail.blade.php
+++ b/apps/kita/resources/views/articles/detail.blade.php
@@ -40,15 +40,11 @@
                         <h3>{{ $article->title }}</h3>
                         <p>{{ $article->member->name }}が{{ $article->created_at->format('Y年m月d日') }}に投稿</p>
                         <div class="row pt-4">
-                            <div class="col-auto">
-                                <p class="text-white bg-primary px-2 rounded">javascript</p>
-                            </div>
-                            <div class="col-auto">
-                                <p class="text-white bg-primary px-2 rounded">Vue</p>
-                            </div>
-                            <div class="col-auto">
-                                <p class="text-white bg-primary px-2 rounded">Vite</p>
-                            </div>
+                            @foreach ($article->tags as $tag)
+                                <div class="col-auto">
+                                    <p class="text-white bg-primary px-2 rounded">{{ $tag->name }}</p>
+                                </div>
+                            @endforeach
                         </div>
                     </div>
                     <div class="py-3 text-secondary">

--- a/apps/kita/resources/views/articles/edit.blade.php
+++ b/apps/kita/resources/views/articles/edit.blade.php
@@ -31,11 +31,10 @@
                         <div class="pb-0">
                             <p>タグ</p>
                         </div>
-                        <select class="form-select border-success" size="3" aria-label="size 3 select example">
-                            <option value="1">PHP</option>
-                            <option value="2">Java</option>
-                            <option value="3">javascript</option>
-                            <option value="4">Ruby</option>
+                        <select class="form-select border-success" size="5" aria-label="タグ選択" name="tags[]" multiple>
+                            @foreach($tags as $tag)
+                                <option value="{{ $tag->id }}" @if(in_array($tag->id, $article->tags->pluck('id')->toArray())) selected @endif>{{ $tag->name }}</option>
+                            @endforeach
                         </select>
                     </div>
                     <div class="px-3 py-4">

--- a/apps/kita/resources/views/user/header.blade.php
+++ b/apps/kita/resources/views/user/header.blade.php
@@ -16,14 +16,14 @@
             <div class="col-12 col-md-6 my-3">
                 <nav class="navbar navbar-expand-lg navbar-dark">
                     <div class="container">
-                        <a class="navbar-brand text-light bg-success px-4" style="border-radius: 50%;" href="#"><h1>Kita</h1></a>
-                        <button class="navbar-toggler my-2" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+                        <a class="navbar-brand text-light bg-success px-4" style="border-radius: 50%;" href="{{ route('article.index') }}"><h1>Kita</h1></a>
+                        <button class="navbar-toggler my-2 bg-success" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                             <span class="navbar-toggler-icon"></span>
                         </button>
                         <div class="justify-content-end collapse navbar-collapse" id="navbarSupportedContent">
                             <ul class="navbar-nav pl-md-4 my-md-0 mt-3 mb-lg-0">
                                 <div class="input-group mx-md-4 mx-2">
-                                    {!! Form::open(['route' => 'article.search', 'method' => 'GET', 'class' => 'd-flex align-items-center']) !!}
+                                    {!! Form::open(['route' => 'article.index', 'method' => 'GET', 'class' => 'd-flex']) !!}
                                     {!! Form::text('search', null, ['class' => 'form-control', 'placeholder' => 'Search for something']) !!}
                                     {!! Form::submit('検索', ['class' => 'btn btn-success col-auto']) !!}
                                     {!! Form::close() !!}

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -86,8 +86,7 @@ Route::middleware(['auth:members'])->group(function () {
 //articles関連 middlewareなし
 Route::group(['prefix' => 'articles'], function () {
 
-    Route::get('/', [ArticleController::class, 'index']);
-    Route::get('/', [ArticleController::class, 'search'])->name('article.search');
+    Route::get('/', [ArticleController::class, 'index'])->name('article.index');
     //詳細表示
     Route::get('/{article_id}', [ArticleController::class, 'show'])->name('article.show');
 

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -44,7 +44,8 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
     Route::get('/article_tags',[TagController::class, 'index'])->name('tag.index');
     Route::get('/article_tags/create',[TagController::class, 'create'])->name('tag.create');
     Route::post('/article_tags',[TagController::class, 'store'])->name('tag.store');
-    Route::get('/article_tags/{id}/edit',[TagController::class, 'edit'])->name('tag.edit');
+    Route::get('/article_tags/{id}/edit', [TagController::class, 'edit'])->name('tag.edit');
+    Route::delete('/article_tags/{id}', [TagController::class, 'destroy'])->name('tag.destroy');
     Route::put('/article_tags/{id}/edit', [TagController::class, 'update'])->name('tag.update');
 });
 


### PR DESCRIPTION
**概要**

タグを含めた記事投稿

**詳細**

- 記事投稿画面にタグの一覧が表示されていること
- コントロールを押しながら、複数選択ができるようになっていること
- タグは最大５個までとする(Qitaと同様)
- タグをつけないで投稿することは可能とする
- (artilce-tagのSeederはまだ未着手)


**チケット**
https://fullspeed.atlassian.net/browse/QKZA-59

**動画・画像**

成功

https://github.com/YoshikiWarashina/Kita/assets/129946179/b6f30c78-2f22-4d01-adec-6aa5366fa161


データを入れる前
<img width="314" alt="スクリーンショット 2023-08-01 20 19 00" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/c4393636-eaa5-402c-9f92-983f47ab56ec">


データを入れた後

<img width="397" alt="スクリーンショット 2023-08-01 20 20 17" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/ed1e7a53-a38f-44d7-a947-24381a28f3fd">


５個より多い場合
<img width="1380" alt="スクリーンショット 2023-08-01 18 47 04" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/a165450a-df7d-4c50-97f8-0dd9155ec0b8">
