### PR TITLE
article edit with tag

### DIFF
--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -98,7 +98,7 @@ class ArticleController extends Controller
     }
 
     /**
-     * Update the specified resource in storage.
+     * 記事の更新
      *
      * @param  \App\Services\ArticleService  $articleService
      * @param  \App\Http\Requests\Article\UpdateRequest $request
@@ -116,7 +116,11 @@ class ArticleController extends Controller
         $article = $articleService->updateArticle($id, $validatedData);
 
         $articleId = $article->id;
-        return redirect('articles/'.$articleId.'/edit')->with('message', '記事編集が完了しました')->with('article', $article);
+
+        return redirect('articles/'.$articleId.'/edit')->with([
+            'message'=> '記事編集が完了しました',
+            'article'=> $article
+        ]);
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Article/ArticleController.php
+++ b/apps/kita/app/Http/Controllers/Article/ArticleController.php
@@ -82,18 +82,19 @@ class ArticleController extends Controller
     }
 
     /**
+     * 記事編集ページ表示
      *
-     * @param  \App\Services\ArticleService  $articleService
+     * @param  \App\Services\ArticleService $articleService
+     * @param  \App\Services\TagService $tagService
      * @param  int  $id
      * @return \Illuminate\Contracts\View\View
-     * Show the form for editing the specified resource.
-     *
      */
-    public function edit(ArticleService $articleService, int $id)
+    public function edit(ArticleService $articleService, TagService $tagService, int $id)
     {
         $article = $articleService->getArticleById($id);
+        $tags = $tagService->getTagsForArticle();
 
-        return view('articles.edit', ['article' => $article]);
+        return view('articles.edit', compact('article', 'tags'));
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -91,4 +91,17 @@ class TagController extends Controller
             'tag' => $tag,
         ]);
     }
+
+    /**
+     * タグ削除
+     * @param App\Services\TagService
+     * @param int $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(TagService $tagService, int $id)
+    {
+        $tagService->deleteTag($id);
+
+        return redirect('admin/article_tags')->with('message', 'タグを削除しました');
+    }
 }

--- a/apps/kita/app/Http/Requests/Article/UpdateRequest.php
+++ b/apps/kita/app/Http/Requests/Article/UpdateRequest.php
@@ -25,6 +25,7 @@ class UpdateRequest extends FormRequest
     {
         return [
             'title' => ['required', 'string', 'max:20'],
+            'tags' => ['array', 'max:5', 'nullable', 'distinct'],
             'contents' =>['required', 'string', 'max:400'],
         ];
     }

--- a/apps/kita/app/Models/Article.php
+++ b/apps/kita/app/Models/Article.php
@@ -60,6 +60,6 @@ class Article extends Model
      */
     public function tags()
     {
-        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id');
+        return $this->belongsToMany(Tag::class, 'article_article_tag', 'article_id', 'article_tag_id')->withTimestamps();
     }
 }

--- a/apps/kita/app/Models/Tag.php
+++ b/apps/kita/app/Models/Tag.php
@@ -32,6 +32,6 @@ class Tag extends Model
      */
     public function articles()
     {
-        return $this->belongsToMany(Article::class, 'article_article_tag', 'article_tag_id', 'article_id');
+        return $this->belongsToMany(Article::class, 'article_article_tag', 'article_tag_id', 'article_id')->withTimestamps();
     }
 }

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -131,24 +131,19 @@ class ArticleService{
             'contents' => $data['contents'],
         ]);
 
-        // タグの関連付け(updated_atを更新するためdetachして再度attachする)
+        $syncData = [];
+
+        // タグの関連付け(if文: タグあり、それ以外: タグなし)
         if (isset($data['tags']) && is_array($data['tags'])) {
             $tags = $data['tags'];
 
-            $timestamp = date('Y-m-d H:i:s'); // 現在の日時を取得
-
-            // 一旦タグの関連付けを削除
-            $article->tags()->detach();
-
-            // 更新したタグを関連付け
+            // タグにcreated_at updated_atを追加
             foreach ($tags as $tag) {
-                $pivotData = [
-                    'created_at' => $timestamp,
-                    'updated_at' => $timestamp,
-                ];
-                $article->tags()->attach($tag, $pivotData); // 中間テーブルにデータを追加
+                $syncData[$tag] = ['created_at' => now(), 'updated_at' => now()];
             }
         }
+        $article->tags()->sync($syncData);
+
         return $article;
     }
 

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -2,11 +2,11 @@
 
 namespace App\Services;
 
-use App\Models\Admin;
 use App\Models\Article;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+use Exception;
+
 class ArticleService{
 
     /**
@@ -121,30 +121,37 @@ class ArticleService{
      * @param int $articleId;
      * @param array $data
      * @return Article
+     * @@throws Exception
      */
     public function updateArticle(int $articleId, array $data)
     {
-        $article = $this->getArticleById($articleId);
+        DB::beginTransaction();
 
-        $article->update([
-            'title' => $data['title'],
-            'contents' => $data['contents'],
-        ]);
+        try {
+            $article = $this->getArticleById($articleId);
 
-        $syncData = [];
+            $article->update([
+                'title' => $data['title'],
+                'contents' => $data['contents'],
+            ]);
 
-        // タグの関連付け(if文: タグあり、それ以外: タグなし)
-        if (isset($data['tags']) && is_array($data['tags'])) {
-            $tags = $data['tags'];
+            $tags = [];
 
-            // タグにcreated_at updated_atを追加
-            foreach ($tags as $tag) {
-                $syncData[$tag] = ['created_at' => now(), 'updated_at' => now()];
+            // タグの関連付け(if文: タグあり、それ以外: タグなし)
+            if (isset($data['tags']) && is_array($data['tags'])) {
+                $tags = $data['tags'];
             }
-        }
-        $article->tags()->sync($syncData);
 
-        return $article;
+            $article->tags()->sync($tags);
+            DB::commit();
+
+            return $article;
+
+        } catch (\Exception $e) {
+            // トランザクションのロールバック
+            DB::rollback();
+            throw $e;
+        }
     }
 
     /**

--- a/apps/kita/app/Services/ArticleService.php
+++ b/apps/kita/app/Services/ArticleService.php
@@ -126,12 +126,29 @@ class ArticleService{
     {
         $article = $this->getArticleById($articleId);
 
-
         $article->update([
             'title' => $data['title'],
             'contents' => $data['contents'],
         ]);
 
+        // タグの関連付け(updated_atを更新するためdetachして再度attachする)
+        if (isset($data['tags']) && is_array($data['tags'])) {
+            $tags = $data['tags'];
+
+            $timestamp = date('Y-m-d H:i:s'); // 現在の日時を取得
+
+            // 一旦タグの関連付けを削除
+            $article->tags()->detach();
+
+            // 更新したタグを関連付け
+            foreach ($tags as $tag) {
+                $pivotData = [
+                    'created_at' => $timestamp,
+                    'updated_at' => $timestamp,
+                ];
+                $article->tags()->attach($tag, $pivotData); // 中間テーブルにデータを追加
+            }
+        }
         return $article;
     }
 

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -106,4 +106,19 @@ class TagService
 
         return $tag;
     }
+
+
+    /**
+     * idをベースにタグを取得し、
+     * 記事との中間テーブルレコードを削除、かつタグ自体も削除
+     *
+     * @param int $id
+     * @return void
+     */
+    public function deleteTag(int $id)
+    {
+        $tag = $this->getTagById($id);
+        $tag->articles()->detach();
+        $tag->delete();
+    }
 }

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -8,6 +8,13 @@
             </div>
         </div>
 
+        @if(session('message'))
+            <div class="alert alert-success">
+                <h5 class="fw-bolder">Success!</h5>
+                {{ session('message') }}
+            </div>
+        @endif
+
         {!! Form::open(['route' => 'tag.index', 'method' => 'GET']) !!}
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">

--- a/apps/kita/resources/views/admin/article_tags/edit.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/edit.blade.php
@@ -22,9 +22,9 @@
                 {{ session('message') }}
             </div>
         @endif
-        {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
         <div class="row">
             <div class="col-md-9 col-12">
+                {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
                 <div class="border rounded bg-white py-3">
                     <div class="col px-4 my-4">
                         <p class="mb-2">ID</p>
@@ -51,13 +51,15 @@
                 <div class="border rounded bg-white py-3 px-3">
                     <div class="col-md-12 col-12 text-center py-2">
                         {!! Form::submit('更新する', ['class' => 'btn btn-primary w-100']) !!}
+                        {!! Form::close() !!}
                     </div>
                     <div class="col-md-12 col-12 text-center py-2">
+                        {!! Form::open(['route' => ['tag.destroy', $tag->id],'method' => 'DELETE', 'onsubmit' => "return confirm('一度削除すると元に戻せません。よろしいですか？');"]) !!}
                         {!! Form::submit('削除する', ['class' => 'btn btn-danger w-100']) !!}
+                        {!! Form::close() !!}
                     </div>
                 </div>
             </div>
         </div>
-        {!! Form::close() !!}
     </div>
 @endsection

--- a/apps/kita/resources/views/articles/edit.blade.php
+++ b/apps/kita/resources/views/articles/edit.blade.php
@@ -31,11 +31,10 @@
                         <div class="pb-0">
                             <p>タグ</p>
                         </div>
-                        <select class="form-select border-success" size="3" aria-label="size 3 select example">
-                            <option value="1">PHP</option>
-                            <option value="2">Java</option>
-                            <option value="3">javascript</option>
-                            <option value="4">Ruby</option>
+                        <select class="form-select border-success" size="5" aria-label="タグ選択" name="tags[]" multiple>
+                            @foreach($tags as $tag)
+                                <option value="{{ $tag->id }}" @if(in_array($tag->id, $article->tags->pluck('id')->toArray())) selected @endif>{{ $tag->name }}</option>
+                            @endforeach
                         </select>
                     </div>
                     <div class="px-3 py-4">

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -44,7 +44,8 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
     Route::get('/article_tags',[TagController::class, 'index'])->name('tag.index');
     Route::get('/article_tags/create',[TagController::class, 'create'])->name('tag.create');
     Route::post('/article_tags',[TagController::class, 'store'])->name('tag.store');
-    Route::get('/article_tags/{id}/edit',[TagController::class, 'edit'])->name('tag.edit');
+    Route::get('/article_tags/{id}/edit', [TagController::class, 'edit'])->name('tag.edit');
+    Route::delete('/article_tags/{id}', [TagController::class, 'destroy'])->name('tag.destroy');
     Route::put('/article_tags/{id}/edit', [TagController::class, 'update'])->name('tag.update');
 });
 


### PR DESCRIPTION
**概要**

タグを含めた記事編集

**詳細**

- 編集ページに行くと、すでに紐付いているタグをマーキングしておくこと
- タグの変更を加えなくても編集ができること (自分自身の重複制限は排除)
- タグの変更を加えなく、記事だけを変更した時、タグのidが更新されてしまうことの問題解決
- バリデーション５個まで
- 未選択も可能とする

**チケット**
https://fullspeed.atlassian.net/browse/QKZA-63

**動画・画像**

- 新規登録時点
タグid 121 - 123までデータが入っている状態

- 成功 (完全に別のタグで編集したので、タグid 124 - 126になる)

https://github.com/YoshikiWarashina/Kita/assets/129946179/558fc796-2b2b-4a71-97b7-eeef10a44682

<img width="390" alt="スクリーンショット 2023-08-04 19 50 51" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/2c3c98a3-26d4-4efa-a399-80ae5b6ef1fd">

- 自分自身の重複排除(idの更新なし。ただし、時間だけupdate)

https://github.com/YoshikiWarashina/Kita/assets/129946179/f6bbcab4-810a-42dd-a72e-883eae6fe1f8

<img width="388" alt="スクリーンショット 2023-08-04 19 52 57" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/e8576bc9-4801-4845-a932-b803670fe115">

- バリデーション(5個まで)

<img width="1367" alt="スクリーンショット 2023-08-04 19 55 19" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/2d9f3131-f05a-4d9b-8421-908ed5b0343a">

- 未選択更新可能

https://github.com/YoshikiWarashina/Kita/assets/129946179/e5f9e849-aaf8-4b20-8399-16e39b8bf7b4

(最終的に記事にはタグをつけていないため、シーダーで入れた120個だけがテーブルにある状態)
<img width="413" alt="スクリーンショット 2023-08-04 19 57 19" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/f9108106-b58c-4c1b-81f5-a78ff5f51048">
