### PR TITLE
tag delete

### DIFF
--- a/apps/kita/app/Http/Controllers/Tag/TagController.php
+++ b/apps/kita/app/Http/Controllers/Tag/TagController.php
@@ -91,4 +91,17 @@ class TagController extends Controller
             'tag' => $tag,
         ]);
     }
+
+    /**
+     * タグ削除
+     * @param App\Services\TagService
+     * @param int $id
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function destroy(TagService $tagService, int $id)
+    {
+        $tagService->deleteTag($id);
+
+        return redirect('admin/article_tags')->with('message', 'タグを削除しました');
+    }
 }

--- a/apps/kita/app/Services/TagService.php
+++ b/apps/kita/app/Services/TagService.php
@@ -106,4 +106,19 @@ class TagService
 
         return $tag;
     }
+
+
+    /**
+     * idをベースにタグを取得し、
+     * 記事との中間テーブルレコードを削除、かつタグ自体も削除
+     *
+     * @param int $id
+     * @return void
+     */
+    public function deleteTag(int $id)
+    {
+        $tag = $this->getTagById($id);
+        $tag->articles()->detach();
+        $tag->delete();
+    }
 }

--- a/apps/kita/resources/views/admin/article_tags.blade.php
+++ b/apps/kita/resources/views/admin/article_tags.blade.php
@@ -8,6 +8,13 @@
             </div>
         </div>
 
+        @if(session('message'))
+            <div class="alert alert-success">
+                <h5 class="fw-bolder">Success!</h5>
+                {{ session('message') }}
+            </div>
+        @endif
+
         {!! Form::open(['route' => 'tag.index', 'method' => 'GET']) !!}
         <div class="row">
             <div class="col-md-12 col-12 justify-content-center">

--- a/apps/kita/resources/views/admin/article_tags/edit.blade.php
+++ b/apps/kita/resources/views/admin/article_tags/edit.blade.php
@@ -22,9 +22,9 @@
                 {{ session('message') }}
             </div>
         @endif
-        {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
         <div class="row">
             <div class="col-md-9 col-12">
+                {!! Form::open(['route' => ['tag.update', $tag->id], 'method' => 'PUT']) !!}
                 <div class="border rounded bg-white py-3">
                     <div class="col px-4 my-4">
                         <p class="mb-2">ID</p>
@@ -51,13 +51,15 @@
                 <div class="border rounded bg-white py-3 px-3">
                     <div class="col-md-12 col-12 text-center py-2">
                         {!! Form::submit('更新する', ['class' => 'btn btn-primary w-100']) !!}
+                        {!! Form::close() !!}
                     </div>
                     <div class="col-md-12 col-12 text-center py-2">
+                        {!! Form::open(['route' => ['tag.destroy', $tag->id],'method' => 'DELETE', 'onsubmit' => "return confirm('一度削除すると元に戻せません。よろしいですか？');"]) !!}
                         {!! Form::submit('削除する', ['class' => 'btn btn-danger w-100']) !!}
+                        {!! Form::close() !!}
                     </div>
                 </div>
             </div>
         </div>
-        {!! Form::close() !!}
     </div>
 @endsection

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -44,7 +44,8 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
     Route::get('/article_tags',[TagController::class, 'index'])->name('tag.index');
     Route::get('/article_tags/create',[TagController::class, 'create'])->name('tag.create');
     Route::post('/article_tags',[TagController::class, 'store'])->name('tag.store');
-    Route::get('/article_tags/{id}/edit',[TagController::class, 'edit'])->name('tag.edit');
+    Route::get('/article_tags/{id}/edit', [TagController::class, 'edit'])->name('tag.edit');
+    Route::delete('/article_tags/{id}', [TagController::class, 'destroy'])->name('tag.destroy');
     Route::put('/article_tags/{id}/edit', [TagController::class, 'update'])->name('tag.update');
 });
 


### PR DESCRIPTION
**概要**

タグ削除

**詳細**

- タグがテーブルから削除できること。(物理削除)
- 削除の確認メッセージ(削除前最終確認)が出ること。
- 削除後は、タグ一覧へ遷移すること。
- 削除完了確認メッセージが出ること。
- 中間テーブルのレコードも削除されること。


**チケット**
https://fullspeed.atlassian.net/browse/QKZA-64

**動画・画像**

成功

id=20のタグを削除

https://github.com/YoshikiWarashina/Kita/assets/129946179/6602016d-49d7-4c18-8fe6-a8dc68656a65

id=20のタグがテーブルから削除
<img width="376" alt="スクリーンショット 2023-08-07 12 22 24" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/6cd6a1cd-2814-4c18-a0dd-41f7a362f93c">

タグのid=20のレコードが中間テーブルからも削除(id = 45がなくなっている)
<img width="396" alt="スクリーンショット 2023-08-07 12 23 36" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/b6aebc8b-0836-4556-9fde-76a26d9f799a">
