### PR TITLE
independent logout

### DIFF
--- a/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -23,9 +23,7 @@ class LoginController extends Controller
     |
     */
 
-    use AuthenticatesUsers {
-        logout as performLogout;
-    }
+    use AuthenticatesUsers;
 
 
     /**

--- a/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -1,5 +1,6 @@
 <?php
-namespace App\Http\Controllers\Admin;
+namespace App\Http\Controllers\Admin\Auth;
+
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\JsonResponse;

--- a/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -66,7 +66,7 @@ class LoginController extends Controller
      * 前にアクセスしたページに限らず、ログイン後はadmin一覧にいく
      *
      * @param Request $request
-     * @return Response|JsonResponse|RedirectResponse
+     * @return JsonResponse|RedirectResponse
      */
 
     protected function sendLoginResponse(Request $request)
@@ -81,7 +81,7 @@ class LoginController extends Controller
 
         return $request->wantsJson()
             ? new JsonResponse([], 204)
-            : redirect()->route('admin_users.index');
+            : redirect(route('admin_users.index'));
     }
 
 
@@ -89,13 +89,15 @@ class LoginController extends Controller
      * ログアウト後はログインページにいく(user, adminの連結を排除)
      *
      * @param  Request  $request
-     * @return RedirectResponse
+     * @return JsonResponse|RedirectResponse
      */
 
     public function logout(Request $request)
     {
         $this->guard()->logout();
 
-        return redirect()->route('admin.login.form');
+        return $request->wantsJson()
+            ? new JsonResponse([], 204)
+            : redirect(route('admin.login.form'));
     }
 }

--- a/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -6,6 +6,10 @@ use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Contracts\View\View;
+use Illuminate\Contracts\Auth\Guard;
 
 class LoginController extends Controller
 {
@@ -40,7 +44,7 @@ class LoginController extends Controller
     /**
      * Get the guard instance for the admin authentication.
      *
-     * @return \Illuminate\Contracts\Auth\Guard
+     * @return Guard
      */
 
     protected function guard()
@@ -50,7 +54,7 @@ class LoginController extends Controller
 
     /**
      * 管理者側のログイン画面へ遷移
-     * @return \Illuminate\Contracts\View\View
+     * @return View
      */
 
     public function showLoginForm()
@@ -61,8 +65,8 @@ class LoginController extends Controller
     /**
      * 前にアクセスしたページに限らず、ログイン後はadmin一覧にいく
      *
-     * @param Illuminate\Http\Request $request
-     * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     * @param Request $request
+     * @return Response|JsonResponse|RedirectResponse
      */
 
     protected function sendLoginResponse(Request $request)
@@ -84,8 +88,8 @@ class LoginController extends Controller
     /**
      * ログアウト後はログインページにいく(user, adminの連結を排除)
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\RedirectResponse
+     * @param  Request  $request
+     * @return RedirectResponse
      */
 
     public function logout(Request $request)

--- a/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/LoginController.php
@@ -6,7 +6,6 @@ use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
-use Illuminate\Http\Response;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Contracts\View\View;
 use Illuminate\Contracts\Auth\Guard;
@@ -63,25 +62,25 @@ class LoginController extends Controller
     }
 
     /**
-     * 前にアクセスしたページに限らず、ログイン後はadmin一覧にいく
+     * ログイン後のリダイレクト先
      *
-     * @param Request $request
-     * @return JsonResponse|RedirectResponse
+     * @return string
      */
 
-    protected function sendLoginResponse(Request $request)
+    protected function redirectTo()
     {
-        $request->session()->regenerate();
+        return route('admin_users.index');
+    }
 
-        $this->clearLoginAttempts($request);
+    /**
+     * ログイン後のリダイレクト処理
+     *
+     * @return RedirectResponse
+     */
 
-        if ($response = $this->authenticated($request, $this->guard()->user())) {
-            return $response;
-        }
-
-        return $request->wantsJson()
-            ? new JsonResponse([], 204)
-            : redirect(route('admin_users.index'));
+    protected function authenticated(Request $request, $user)
+    {
+        return redirect($this->redirectTo());
     }
 
 

--- a/apps/kita/app/Http/Controllers/Admin/Auth/RegisterController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/RegisterController.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Contracts\Auth\Guard;
 
 class RegisterController extends Controller
 {
@@ -43,7 +44,7 @@ class RegisterController extends Controller
     /**
      * Get the guard instance for the admin authentication.
      *
-     * @return \Illuminate\Contracts\Auth\Guard
+     * @return Guard
      */
 
     protected function guard()

--- a/apps/kita/app/Http/Controllers/Admin/Auth/RegisterController.php
+++ b/apps/kita/app/Http/Controllers/Admin/Auth/RegisterController.php
@@ -1,12 +1,13 @@
 <?php
-namespace App\Http\Controllers\Admin;
+namespace App\Http\Controllers\Admin\Auth;
+
 use App\Http\Controllers\Controller;
-use App\Providers\RouteServiceProvider;
 use App\Models\Admin;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Support\Facades\Auth;
+
 class RegisterController extends Controller
 {
     /*

--- a/apps/kita/app/Http/Controllers/Admin/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Admin/LoginController.php
@@ -5,6 +5,7 @@ use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Http\Request;
+
 class LoginController extends Controller
 {
     /*
@@ -21,17 +22,14 @@ class LoginController extends Controller
     use AuthenticatesUsers {
         logout as performLogout;
     }
-    /**
-     * Where to redirect users after login.
-     *
-     * @var string
-     */
-    protected $redirectTo = '/admin/admin_users';
+
+
     /**
      * Create a new controller instance.
      *
      * @return void
      */
+
     public function __construct()
     {
         $this->middleware('guest:admins')->except('logout');
@@ -53,6 +51,7 @@ class LoginController extends Controller
      * 管理者側のログイン画面へ遷移
      * @return \Illuminate\Contracts\View\View
      */
+
     public function showLoginForm()
     {
         return view('admin.login');
@@ -64,6 +63,7 @@ class LoginController extends Controller
      * @param Illuminate\Http\Request $request
      * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
+
     protected function sendLoginResponse(Request $request)
     {
         $request->session()->regenerate();
@@ -84,21 +84,13 @@ class LoginController extends Controller
      * ログアウト後はログインページにいく(user, adminの連結を排除)
      *
      * @param  \Illuminate\Http\Request  $request
-     * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     * @return \Illuminate\Http\RedirectResponse
      */
 
     public function logout(Request $request)
     {
-        Auth::guard('admins')->logout();
+        $this->guard()->logout();
 
-        $request->session()->regenerateToken();
-
-        if ($response = $this->loggedOut($request)) {
-            return $response;
-        }
-
-        return $request->wantsJson()
-            ? new JsonResponse([], 204)
-            : redirect()->route('admin.login.form');
+        return redirect()->route('admin.login.form');
     }
 }

--- a/apps/kita/app/Http/Controllers/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Auth/LoginController.php
@@ -24,17 +24,11 @@ class LoginController extends Controller
     use AuthenticatesUsers;
 
     /**
-     * Where to redirect users after login.
-     *
-     * @var string
-     */
-    protected $redirectTo = '/articles';
-
-    /**
      * Create a new controller instance.
      *
      * @return void
      */
+
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
@@ -46,6 +40,7 @@ class LoginController extends Controller
      * @param Illuminate\Http\Request $request
      * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
+
     protected function sendLoginResponse(Request $request)
     {
         $request->session()->regenerate();
@@ -67,18 +62,11 @@ class LoginController extends Controller
      * @param \Illuminate\Http\Request $request
      * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
+
     public function logout(Request $request)
     {
-        Auth::guard('members')->logout();
+        $this->guard()->logout();
 
-        $request->session()->regenerateToken();
-
-        if ($response = $this->loggedOut($request)) {
-            return $response;
-        }
-
-        return $request->wantsJson()
-            ? new JsonResponse([], 204)
-            : redirect()->route('login.form');
+        return redirect()->route('login.form');
     }
 }

--- a/apps/kita/app/Http/Controllers/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Auth/LoginController.php
@@ -3,9 +3,10 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 
 class LoginController extends Controller
 {
@@ -37,5 +38,47 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    /**
+     * 前にアクセスしたページに限らず、ログイン後は記事一覧にいく
+     *
+     * @param Illuminate\Http\Request $request
+     * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     */
+    protected function sendLoginResponse(Request $request)
+    {
+        $request->session()->regenerate();
+
+        $this->clearLoginAttempts($request);
+
+        if ($response = $this->authenticated($request, $this->guard()->user())) {
+            return $response;
+        }
+
+        return $request->wantsJson()
+            ? new JsonResponse([], 204)
+            : redirect()->route('article.index');
+    }
+
+    /**
+     * ログアウト後はログインページにいく(user, adminの連結を排除)
+     *
+     * @param \Illuminate\Http\Request $request
+     * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     */
+    public function logout(Request $request)
+    {
+        Auth::guard('members')->logout();
+
+        $request->session()->regenerateToken();
+
+        if ($response = $this->loggedOut($request)) {
+            return $response;
+        }
+
+        return $request->wantsJson()
+            ? new JsonResponse([], 204)
+            : redirect()->route('login.form');
     }
 }

--- a/apps/kita/app/Http/Controllers/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Auth/LoginController.php
@@ -31,7 +31,18 @@ class LoginController extends Controller
 
     public function __construct()
     {
-        $this->middleware('guest')->except('logout');
+        $this->middleware('guest:members')->except('logout');
+    }
+
+    /**
+     * Get the guard instance for the user authentication.
+     *
+     * @return \Illuminate\Contracts\Auth\Guard
+     */
+
+    protected function guard()
+    {
+        return Auth::guard('members');
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Auth/RegisterController.php
+++ b/apps/kita/app/Http/Controllers/Auth/RegisterController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Providers\RouteServiceProvider;
+use Illuminate\Support\Facades\Auth;
 use App\Models\Member;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
@@ -39,6 +39,17 @@ class RegisterController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+    }
+
+    /**
+     * Get the guard instance for the user authentication.
+     *
+     * @return \Illuminate\Contracts\Auth\Guard
+     */
+
+    protected function guard()
+    {
+        return Auth::guard('members');
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Auth/RegisterController.php
+++ b/apps/kita/app/Http/Controllers/Auth/RegisterController.php
@@ -38,7 +38,7 @@ class RegisterController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest');
+        $this->middleware('guest:members');
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Member/Auth/ConfirmPasswordController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/ConfirmPasswordController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;

--- a/apps/kita/app/Http/Controllers/Member/Auth/ForgotPasswordController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/ForgotPasswordController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\SendsPasswordResetEmails;

--- a/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
@@ -48,7 +48,7 @@ class LoginController extends Controller
     /**
      * 前にアクセスしたページに限らず、ログイン後は記事一覧にいく
      *
-     * @param Illuminate\Http\Request $request
+     * @param \Illuminate\Http\Request $request
      * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
      */
 

--- a/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
@@ -7,6 +7,9 @@ use Illuminate\Foundation\Auth\AuthenticatesUsers;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Contracts\Auth\Guard;
+use Illuminate\Http\Response;
+use Illuminate\Http\RedirectResponse;
 
 class LoginController extends Controller
 {
@@ -37,7 +40,7 @@ class LoginController extends Controller
     /**
      * Get the guard instance for the user authentication.
      *
-     * @return \Illuminate\Contracts\Auth\Guard
+     * @return Guard
      */
 
     protected function guard()
@@ -48,8 +51,8 @@ class LoginController extends Controller
     /**
      * 前にアクセスしたページに限らず、ログイン後は記事一覧にいく
      *
-     * @param \Illuminate\Http\Request $request
-     * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     * @param Request $request
+     * @return Response|JsonResponse|RedirectResponse
      */
 
     protected function sendLoginResponse(Request $request)
@@ -70,8 +73,8 @@ class LoginController extends Controller
     /**
      * ログアウト後はログインページにいく(user, adminの連結を排除)
      *
-     * @param \Illuminate\Http\Request $request
-     * @return　\Illuminate\Http\Response|\Illuminate\Http\JsonResponse|\Illuminate\Http\RedirectResponse
+     * @param Request $request
+     * @return Response|JsonResponse|RedirectResponse
      */
 
     public function logout(Request $request)

--- a/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
@@ -47,7 +47,7 @@ class LoginController extends Controller
     {
         return Auth::guard('members');
     }
-    
+
     /**
      * ログイン後のリダイレクト先
      *

--- a/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
@@ -47,27 +47,27 @@ class LoginController extends Controller
     {
         return Auth::guard('members');
     }
-
+    
     /**
-     * 前にアクセスしたページに限らず、ログイン後は記事一覧にいく
+     * ログイン後のリダイレクト先
      *
-     * @param Request $request
-     * @return Response|JsonResponse|RedirectResponse
+     * @return string
      */
 
-    protected function sendLoginResponse(Request $request)
+    protected function redirectTo()
     {
-        $request->session()->regenerate();
+        return route('article.index');
+    }
 
-        $this->clearLoginAttempts($request);
+    /**
+     * ログイン後のリダイレクト処理
+     *
+     * @return RedirectResponse
+     */
 
-        if ($response = $this->authenticated($request, $this->guard()->user())) {
-            return $response;
-        }
-
-        return $request->wantsJson()
-            ? new JsonResponse([], 204)
-            : redirect(route('article.index'));
+    protected function authenticated(Request $request, $user)
+    {
+        return redirect($this->redirectTo());
     }
 
     /**

--- a/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/LoginController.php
@@ -67,7 +67,7 @@ class LoginController extends Controller
 
         return $request->wantsJson()
             ? new JsonResponse([], 204)
-            : redirect()->route('article.index');
+            : redirect(route('article.index'));
     }
 
     /**
@@ -81,6 +81,8 @@ class LoginController extends Controller
     {
         $this->guard()->logout();
 
-        return redirect()->route('login.form');
+        return $request->wantsJson()
+            ? new JsonResponse([], 204)
+            : redirect(route('login.form'));
     }
 }

--- a/apps/kita/app/Http/Controllers/Member/Auth/PasswordController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/PasswordController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Password\UpdatepassRequest;
@@ -12,7 +12,7 @@ class PasswordController extends Controller
      * プロフィール編集機能（ユーザー名、メールアドレス）
      *
      * @param PasswordService $passwordService;
-     * @param UpdatepassRequestRequest $request
+     * @param UpdatepassRequest $request
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(PasswordService $passwordService, UpdatepassRequest $request)

--- a/apps/kita/app/Http/Controllers/Member/Auth/ProfileController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/ProfileController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Services\ProfileService;
 use App\Http\Requests\Profile\UpdateRequest;
+use App\Services\ProfileService;
 use Illuminate\Support\Facades\Auth;
 
 class ProfileController extends Controller

--- a/apps/kita/app/Http/Controllers/Member/Auth/RegisterController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/RegisterController.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
-use Illuminate\Support\Facades\Auth;
 use App\Models\Member;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 

--- a/apps/kita/app/Http/Controllers/Member/Auth/ResetPasswordController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/ResetPasswordController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;

--- a/apps/kita/app/Http/Controllers/Member/Auth/VerificationController.php
+++ b/apps/kita/app/Http/Controllers/Member/Auth/VerificationController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers\Auth;
+namespace App\Http\Controllers\Member\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;

--- a/apps/kita/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/apps/kita/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,11 +19,11 @@ class RedirectIfAuthenticated
         $guards = empty($guards) ? [null] : $guards;
         foreach ($guards as $guard) {
             //redirect destination for admins
-            if($guard == "admins" && Auth::guard($guard)->check()) {   //追記
-                return redirect('admin/admin_users');                        //追記
+            if($guard == "admins" && Auth::guard($guard)->check()) {
+                return redirect('admin/admin_users');
             }
             //redirect destination for members
-            if (Auth::guard($guard)->check()) {
+            if ($guard == "members" && Auth::guard($guard)->check()) {
                 return redirect('articles');
             }
         }

--- a/apps/kita/app/Models/Admin.php
+++ b/apps/kita/app/Models/Admin.php
@@ -3,7 +3,6 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 
@@ -12,7 +11,6 @@ class Admin extends Authenticatable
     use HasFactory;
     use SoftDeletes;
 
-    protected $guard = 'admins';
 
     protected $table = 'admin_users';
 
@@ -28,7 +26,4 @@ class Admin extends Authenticatable
         'remember_token',
     ];
 
-//    protected $casts = [
-//        'email_verified_at' => 'datetime',
-//    ];
 }

--- a/apps/kita/app/Models/Member.php
+++ b/apps/kita/app/Models/Member.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-// use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;

--- a/apps/kita/composer.json
+++ b/apps/kita/composer.json
@@ -13,6 +13,7 @@
         "laravelcollective/html": "^6.4"
     },
     "require-dev": {
+        "barryvdh/laravel-debugbar": "^3.8",
         "fakerphp/faker": "^1.9.1",
         "laravel/pint": "^1.0",
         "laravel/sail": "^1.0.1",

--- a/apps/kita/composer.lock
+++ b/apps/kita/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df631226647e2b9b8fa0e6bf1a7baa03",
+    "content-hash": "3234fc513ceb73f4c2581fe2103b1bac",
     "packages": [
         {
             "name": "brick/math",
@@ -5474,6 +5474,90 @@
     ],
     "packages-dev": [
         {
+            "name": "barryvdh/laravel-debugbar",
+            "version": "v3.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-debugbar.git",
+                "reference": "56a2dc1da9d3219164074713983eef68996386cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-debugbar/zipball/56a2dc1da9d3219164074713983eef68996386cf",
+                "reference": "56a2dc1da9d3219164074713983eef68996386cf",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/routing": "^9|^10",
+                "illuminate/session": "^9|^10",
+                "illuminate/support": "^9|^10",
+                "maximebf/debugbar": "^1.18.2",
+                "php": "^8.0",
+                "symfony/finder": "^6"
+            },
+            "require-dev": {
+                "mockery/mockery": "^1.3.3",
+                "orchestra/testbench-dusk": "^5|^6|^7|^8",
+                "phpunit/phpunit": "^8.5.30|^9.0",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.8-dev"
+                },
+                "laravel": {
+                    "providers": [
+                        "Barryvdh\\Debugbar\\ServiceProvider"
+                    ],
+                    "aliases": {
+                        "Debugbar": "Barryvdh\\Debugbar\\Facades\\Debugbar"
+                    }
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "Barryvdh\\Debugbar\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "PHP Debugbar integration for Laravel",
+            "keywords": [
+                "debug",
+                "debugbar",
+                "laravel",
+                "profiler",
+                "webprofiler"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-debugbar/issues",
+                "source": "https://github.com/barryvdh/laravel-debugbar/tree/v3.8.2"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-07-26T04:57:49+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "2.0.0",
             "source": {
@@ -5925,6 +6009,72 @@
                 "source": "https://github.com/laravel/ui/tree/v4.2.2"
             },
             "time": "2023-05-09T19:47:28+00:00"
+        },
+        {
+            "name": "maximebf/debugbar",
+            "version": "v1.18.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maximebf/php-debugbar.git",
+                "reference": "17dcf3f6ed112bb85a37cf13538fd8de49f5c274"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/17dcf3f6ed112bb85a37cf13538fd8de49f5c274",
+                "reference": "17dcf3f6ed112bb85a37cf13538fd8de49f5c274",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8",
+                "psr/log": "^1|^2|^3",
+                "symfony/var-dumper": "^4|^5|^6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=7.5.20 <10.0",
+                "twig/twig": "^1.38|^2.7|^3.0"
+            },
+            "suggest": {
+                "kriswallsmith/assetic": "The best way to manage assets",
+                "monolog/monolog": "Log using Monolog",
+                "predis/predis": "Redis storage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DebugBar\\": "src/DebugBar/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Maxime Bouroumeau-Fuseau",
+                    "email": "maxime.bouroumeau@gmail.com",
+                    "homepage": "http://maximebf.com"
+                },
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "Debug bar in the browser for php application",
+            "homepage": "https://github.com/maximebf/php-debugbar",
+            "keywords": [
+                "debug",
+                "debugbar"
+            ],
+            "support": {
+                "issues": "https://github.com/maximebf/php-debugbar/issues",
+                "source": "https://github.com/maximebf/php-debugbar/tree/v1.18.2"
+            },
+            "time": "2023-02-04T15:27:00+00:00"
         },
         {
             "name": "mockery/mockery",

--- a/apps/kita/resources/views/admin/admin_menu/sidebar.blade.php
+++ b/apps/kita/resources/views/admin/admin_menu/sidebar.blade.php
@@ -29,13 +29,13 @@
                     </a>
                 </li>
                 <li class="nav-item">
-                    {!! Form::open(['route' => 'admin.logout', 'method' => 'POST']) !!}
-                    {!! csrf_field() !!} <!-- CSRF トークンを追加 -->
+                    {{ Form::open(['route' => 'admin.logout', 'method' => 'POST']) }}
+                    @csrf
                     <button type="submit" class="btn-link nav-link text-white">
                         <i class="nav-icon fa-solid fa-door-open"></i>
                         <p>ログアウト</p>
                     </button>
-                    {!! Form::close() !!}
+                    {{ Form::close() }}
                 </li>
             </ul>
         </nav>

--- a/apps/kita/resources/views/admin/admin_menu/sidebar.blade.php
+++ b/apps/kita/resources/views/admin/admin_menu/sidebar.blade.php
@@ -29,7 +29,7 @@
                     </a>
                 </li>
                 <li class="nav-item">
-                    {!! Form::open(['route' => 'admin/logout', 'method' => 'POST']) !!}
+                    {!! Form::open(['route' => 'admin.logout', 'method' => 'POST']) !!}
                     {!! csrf_field() !!} <!-- CSRF トークンを追加 -->
                     <button type="submit" class="btn-link nav-link text-white">
                         <i class="nav-icon fa-solid fa-door-open"></i>

--- a/apps/kita/resources/views/admin/login.blade.php
+++ b/apps/kita/resources/views/admin/login.blade.php
@@ -37,13 +37,8 @@
                                 </div>
                                 <div class="col-md-4 col-12 px-4 my-4">
                                     <button type="submit" class="btn btn-primary col-12">
-                                        {{ __('Login') }}
+                                        {{ __('ログイン') }}
                                     </button>
-                                    @if (Route::has('password.request'))
-                                        <a class="btn btn-link" href="{{ url('admin/password.request') }}">
-                                            {{ __('Forgot Your Password?') }}
-                                        </a>
-                                    @endif
                                 </div>
                             </div>
                         </div>

--- a/apps/kita/resources/views/admin/login.blade.php
+++ b/apps/kita/resources/views/admin/login.blade.php
@@ -8,7 +8,7 @@
                         <h1><strong>Kita</strong> Administrator console</h1>
                     </div>
                 </div>
-                <form method="POST" action="{{ url('admin/login') }}">
+                {{ Form::open(['route' => 'admin.login', 'method' => 'POST']) }}
                     @csrf
                     <div class="row d-flex justify-content-center">
                         <div class="col-md-10 col-12">
@@ -17,7 +17,7 @@
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('メールアドレス') }}</p>
                                     </div>
-                                    <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
+                                    {{ Form::email('email', old('email'), ['class' => 'form-control' . ($errors->has('email') ? ' is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'email', 'autofocus' => 'autofocus']) }}
                                     @error('email')
                                     <span class="invalid-feedback" role="alert">
                                             <strong>{{ $message }}</strong>
@@ -28,7 +28,7 @@
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('パスワード') }}</p>
                                     </div>
-                                    <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
+                                    {{ Form::password('password', ['class' => 'form-control' . ($errors->has('password') ? ' is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'current-password']) }}
                                     @error('password')
                                     <span class="invalid-feedback" role="alert">
                                             <strong>{{ $message }}</strong>
@@ -36,14 +36,12 @@
                                     @enderror
                                 </div>
                                 <div class="col-md-4 col-12 px-4 my-4">
-                                    <button type="submit" class="btn btn-primary col-12">
-                                        {{ __('ログイン') }}
-                                    </button>
+                                    {{ Form::button(__('ログイン'), ['type' => 'submit', 'class' => 'btn btn-primary col-12']) }}
                                 </div>
                             </div>
                         </div>
                     </div>
-                </form>
+                {{ Form::close() }}
             </div>
         </div>
     </div>

--- a/apps/kita/resources/views/auth/login.blade.php
+++ b/apps/kita/resources/views/auth/login.blade.php
@@ -16,7 +16,7 @@
                         <div class="border rounded bg-white pt-3 px-3">
                             <div class="mx-4">
                                 <div class="row">
-                                    <p class="text-end">新規会員登録は<a href="{{ route('member.register') }}" style="text-decoration: none;">こちら</a></p>
+                                    <p class="text-end">新規会員登録は<a href="{{ route('register.form') }}" style="text-decoration: none;">こちら</a></p>
                                 </div>
                             </div>
                             <form method="POST" action="{{ route('login') }}">

--- a/apps/kita/resources/views/auth/login.blade.php
+++ b/apps/kita/resources/views/auth/login.blade.php
@@ -19,13 +19,13 @@
                                     <p class="text-end">新規会員登録は<a href="{{ route('register.form') }}" style="text-decoration: none;">こちら</a></p>
                                 </div>
                             </div>
-                            <form method="POST" action="{{ route('login') }}">
+                            {{ Form::open(['route' => 'login', 'method' => 'POST']) }}
                                 @csrf
                                 <div class="col px-4 mb-4">
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('メールアドレス') }}</p>
                                     </div>
-                                    <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email" autofocus>
+                                    {{ Form::email('email', old('email'), ['id' => 'email', 'class' => 'form-control ' . ($errors->has('email') ? 'is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'email', 'autofocus' => 'autofocus']) }}
 
                                     @error('email')
                                     <span class="invalid-feedback" role="alert">
@@ -37,7 +37,7 @@
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('パスワード') }}</p>
                                     </div>
-                                    <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="current-password">
+                                    {{ Form::password('password', ['id' => 'password', 'class' => 'form-control ' . ($errors->has('password') ? 'is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'current-password']) }}
 
                                     @error('password')
                                     <span class="invalid-feedback" role="alert">
@@ -46,11 +46,9 @@
                                     @enderror
                                 </div>
                                 <div class="col-md-4 col-12 px-4 my-4">
-                                    <button type="submit" class="btn btn-success">
-                                        {{ __('ログイン') }}
-                                    </button>
+                                    {{ Form::button(__('ログイン'), ['type' => 'submit', 'class' => 'btn btn-success']) }}
                                 </div>
-                            </form>
+                            {{ Form::close() }}
                         </div>
                     </div>
                 </div>

--- a/apps/kita/resources/views/auth/register.blade.php
+++ b/apps/kita/resources/views/auth/register.blade.php
@@ -14,13 +14,13 @@
                             </div>
                         </div>
                         <div class="border rounded bg-white pt-3 px-3">
-                            <form method="POST" action="{{ route('register.form') }}">
+                            {{ Form::open(['route' => 'register', 'method' => 'POST']) }}
                                 @csrf
                                 <div class="col px-4 mb-4">
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('ユーザー名') }}</p>
                                     </div>
-                                    <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
+                                    {{ Form::text('name', old('name'), ['id' => 'name', 'class' => 'form-control ' . ($errors->has('name') ? 'is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'name', 'autofocus' => 'autofocus']) }}
 
                                     @error('name')
                                     <span class="invalid-feedback" role="alert">
@@ -32,7 +32,7 @@
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('メールアドレス') }}</p>
                                     </div>
-                                    <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email">
+                                    {{ Form::email('email', old('email'), ['id' => 'email', 'class' => 'form-control ' . ($errors->has('email') ? 'is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'email']) }}
 
                                     @error('email')
                                     <span class="invalid-feedback" role="alert">
@@ -44,7 +44,7 @@
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('パスワード') }}</p>
                                     </div>
-                                    <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
+                                    {{ Form::password('password', ['id' => 'password', 'class' => 'form-control ' . ($errors->has('password') ? 'is-invalid' : ''), 'required' => 'required', 'autocomplete' => 'new-password']) }}
 
                                     @error('password')
                                     <span class="invalid-feedback" role="alert">
@@ -57,14 +57,12 @@
                                     <div class="row">
                                         <p class="mb-2 col-auto">{{ __('パスワード（確認用）') }}</p>
                                     </div>
-                                    <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
+                                    {{ Form::password('password_confirmation', ['id' => 'password-confirm', 'class' => 'form-control', 'required' => 'required', 'autocomplete' => 'new-password']) }}
                                 </div>
                                 <div class="col-md-4 col-12 px-4 my-4">
-                                    <button type="submit" class="btn btn-success">
-                                        {{ __('登録する') }}
-                                    </button>
+                                    {{ Form::button(__('登録する'), ['type' => 'submit', 'class' => 'btn btn-success']) }}
                                 </div>
-                            </form>
+                            {{ Form::close() }}
                         </div>
                     </div>
                 </div>

--- a/apps/kita/resources/views/auth/register.blade.php
+++ b/apps/kita/resources/views/auth/register.blade.php
@@ -14,7 +14,7 @@
                             </div>
                         </div>
                         <div class="border rounded bg-white pt-3 px-3">
-                            <form method="POST" action="{{ route('member.register') }}">
+                            <form method="POST" action="{{ route('register.form') }}">
                                 @csrf
                                 <div class="col px-4 mb-4">
                                     <div class="row">
@@ -63,12 +63,6 @@
                                     <button type="submit" class="btn btn-success">
                                         {{ __('登録する') }}
                                     </button>
-
-                                    @if (Route::has('password.request'))
-                                        <a class="btn btn-link" href="{{ route('password.request') }}">
-                                            {{ __('Forgot Your Password?') }}
-                                        </a>
-                                    @endif
                                 </div>
                             </form>
                         </div>

--- a/apps/kita/resources/views/user/header.blade.php
+++ b/apps/kita/resources/views/user/header.blade.php
@@ -22,10 +22,10 @@
                         <div class="justify-content-end collapse navbar-collapse" id="navbarSupportedContent">
                             <ul class="navbar-nav pl-md-4 my-md-0 mt-3 mb-lg-0">
                                 <div class="input-group mx-md-4 mx-2">
-                                    {!! Form::open(['route' => 'article.index', 'method' => 'GET', 'class' => 'd-flex']) !!}
-                                    {!! Form::text('search', null, ['class' => 'form-control', 'placeholder' => 'Search for something']) !!}
-                                    {!! Form::submit('検索', ['class' => 'btn btn-success col-auto']) !!}
-                                    {!! Form::close() !!}
+                                    {{ Form::open(['route' => 'article.index', 'method' => 'GET', 'class' => 'd-flex']) }}
+                                    {{ Form::text('search', null, ['class' => 'form-control', 'placeholder' => 'Search for something']) }}
+                                    {{ Form::submit('検索', ['class' => 'btn btn-success col-auto']) }}
+                                    {{ Form::close() }}
                                 </div>
                             </ul>
                             <div class="mx-2">
@@ -41,10 +41,10 @@
                                             <a class="dropdown-item text-primary" href="{{ route('profile.edit') }}">プロフィール編集</a>
                                         </li>
                                         <li>
-                                            <form method="POST" action="{{ route('logout') }}">
-                                                @csrf
-                                                <button type="submit" class="dropdown-item text-primary">ログアウト</button>
-                                            </form>
+                                            {{ Form::open(['method' => 'POST', 'route' => 'logout']) }}
+                                            @csrf
+                                            {{ Form::button('ログアウト', ['type' => 'submit', 'class' => 'dropdown-item text-primary']) }}
+                                            {{ Form::close() }}
                                         </li>
                                     </ul>
                                 </div>

--- a/apps/kita/resources/views/user/header.blade.php
+++ b/apps/kita/resources/views/user/header.blade.php
@@ -28,15 +28,18 @@
                                     {{ Form::close() }}
                                 </div>
                             </ul>
+                            @if(auth()->guard('members')->check())
                             <div class="mx-2">
                                 <a href="{{ route('article.create') }}" class="btn btn-outline-success my-md-0 my-3">記事を作成する</a>
                             </div>
+                            @endif
                             <div class="mx-2">
                                 <div class="dropdown">
                                     <button class="btn btn-success dropdown-toggle　dropdown-toggle-no-caret" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false">
                                         <i class="fa-regular fa-user-circle"></i>
                                     </button>
                                     <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
+                                        @if(auth()->guard('members')->check())
                                         <li>
                                             <a class="dropdown-item text-primary" href="{{ route('profile.edit') }}">プロフィール編集</a>
                                         </li>
@@ -46,6 +49,11 @@
                                             {{ Form::button('ログアウト', ['type' => 'submit', 'class' => 'dropdown-item text-primary']) }}
                                             {{ Form::close() }}
                                         </li>
+                                        @else
+                                        <li>
+                                            <a class="dropdown-item text-primary" href="{{ route('login.form') }}">ログイン</a>
+                                        </li>
+                                        @endif
                                     </ul>
                                 </div>
                             </div>

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -50,9 +50,9 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
 
 
 //admins middlewareなし
-Route::group(['prefix' => 'admin'], function () {
-    Route::get('/login', [\App\Http\Controllers\Admin\Auth\LoginController::class, 'showLoginForm'])->name('admin.login.form');
-    Route::post('/login', [\App\Http\Controllers\Admin\Auth\LoginController::class, 'login'])->name('admin.login');
+Route::prefix('admin')->name('admin.')->group(function () {
+    Route::get('/login', [\App\Http\Controllers\Admin\Auth\LoginController::class, 'showLoginForm'])->name('login.form');
+    Route::post('/login', [\App\Http\Controllers\Admin\Auth\LoginController::class, 'login'])->name('login');
 });
 
 Route::get('/member_registration', [RegisterController::class, 'showRegistrationForm'])->name('register.form');

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -1,16 +1,15 @@
 <?php
 
-use Illuminate\Support\Facades\Route;
-use Illuminate\Support\Facades\Auth;
-use App\Http\Controllers\Auth\RegisterController;
-use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Admin\AdminController;
 use App\Http\Controllers\Article\ArticleController;
 use App\Http\Controllers\Comment\CommentController;
+use App\Http\Controllers\Member\Auth\LoginController;
+use App\Http\Controllers\Member\Auth\PasswordController;
+use App\Http\Controllers\Member\Auth\ProfileController;
+use App\Http\Controllers\Member\Auth\RegisterController;
 use App\Http\Controllers\Member\MemberController;
-use App\Http\Controllers\Auth\ProfileController;
-use App\Http\Controllers\Auth\PasswordController;
 use App\Http\Controllers\Tag\TagController;
+use Illuminate\Support\Facades\Route;
 
 /*
 |--------------------------------------------------------------------------

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -33,7 +33,7 @@ Route::get('/', function () {
 
 //admins middleware
 Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function () {
-    Route::post('/logout', [App\Http\Controllers\Admin\LoginController::class,'logout'])->name('admin/logout');
+    Route::post('/logout', [App\Http\Controllers\Admin\LoginController::class,'logout'])->name('admin.logout');
     Route::get('/admin_users', [AdminController::class, 'index'])->name('admin_users.index');
     Route::get('/admin_users_create', [AdminController::class, 'create'])->name('admin_users.create');
     Route::post('/admin_users', [AdminController::class, 'store'])->name('admin_users.store');
@@ -52,14 +52,14 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
 
 //admins middlewareなし
 Route::group(['prefix' => 'admin'], function () {
-    Route::get('/login', [App\Http\Controllers\Admin\LoginController::class, 'showLoginForm'])->name('admin.login');
-    Route::post('/login', [App\Http\Controllers\Admin\LoginController::class, 'login'])->name('admin/login');
+    Route::get('/login', [App\Http\Controllers\Admin\LoginController::class, 'showLoginForm'])->name('admin.login.form');
+    Route::post('/login', [App\Http\Controllers\Admin\LoginController::class, 'login'])->name('admin.login');
 });
 
-Route::get('/member_registration', [RegisterController::class, 'showRegistrationForm'])->name('member.register');
-Route::post('/member_registration', [RegisterController::class, 'register'])->name('member.register');
-Route::get('login', [LoginController::class, 'showLoginForm'])->name('login');
-Route::post('login', [LoginController::class, 'login']);
+Route::get('/member_registration', [RegisterController::class, 'showRegistrationForm'])->name('register.form');
+Route::post('/member_registration', [RegisterController::class, 'register'])->name('register');
+Route::get('login', [LoginController::class, 'showLoginForm'])->name('login.form');
+Route::post('login', [LoginController::class, 'login'])->name('login');
 Route::post('logout', [LoginController::class, 'logout'])->name('logout');
 
 

--- a/apps/kita/routes/web.php
+++ b/apps/kita/routes/web.php
@@ -32,7 +32,7 @@ Route::get('/', function () {
 
 //admins middleware
 Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function () {
-    Route::post('/logout', [App\Http\Controllers\Admin\LoginController::class,'logout'])->name('admin.logout');
+    Route::post('/logout', [\App\Http\Controllers\Admin\Auth\LoginController::class,'logout'])->name('admin.logout');
     Route::get('/admin_users', [AdminController::class, 'index'])->name('admin_users.index');
     Route::get('/admin_users_create', [AdminController::class, 'create'])->name('admin_users.create');
     Route::post('/admin_users', [AdminController::class, 'store'])->name('admin_users.store');
@@ -51,8 +51,8 @@ Route::group(['prefix' => 'admin', 'middleware' => ['auth:admins']], function ()
 
 //admins middlewareなし
 Route::group(['prefix' => 'admin'], function () {
-    Route::get('/login', [App\Http\Controllers\Admin\LoginController::class, 'showLoginForm'])->name('admin.login.form');
-    Route::post('/login', [App\Http\Controllers\Admin\LoginController::class, 'login'])->name('admin.login');
+    Route::get('/login', [\App\Http\Controllers\Admin\Auth\LoginController::class, 'showLoginForm'])->name('admin.login.form');
+    Route::post('/login', [\App\Http\Controllers\Admin\Auth\LoginController::class, 'login'])->name('admin.login');
 });
 
 Route::get('/member_registration', [RegisterController::class, 'showRegistrationForm'])->name('register.form');


### PR DESCRIPTION
**概要**

ログイン・ログアウト関連の修正を行う

**詳細**

- ログイン後のリダイレクト先の変数を削除 (middlewareで弾いた時のurlを記憶しておく機能を排除)
 ->その代わり、ログイン後は必ず記事一覧・admin一覧に遷移するようにする

- 片方がログアウトしてももう片方が維持されるように

- ログインのビュー修正 → ファサードで

- routingの名前被りを解決

- ログインしていない場合、記事投稿・プロフィール変更・ログアウトボタンを削除
 ->その代わり、ログインへ遷移するボタンへと変更

**チケット**
https://fullspeed.atlassian.net/browse/QKZA-78

**動画・画像**
ログイン後は必ず記事一覧・admin一覧に遷移するように

https://github.com/YoshikiWarashina/Kita/assets/129946179/04a4a29c-7e54-4b1f-80fc-767777b188b8


https://github.com/YoshikiWarashina/Kita/assets/129946179/921ac47a-ff49-467f-8a91-a5e63a706d2d

片方がログインしても、もう片方は維持

１userでログイン

https://github.com/YoshikiWarashina/Kita/assets/129946179/c176afac-41e2-4fa2-bfd7-3cb26341a68b

２adminでログイン

https://github.com/YoshikiWarashina/Kita/assets/129946179/239ef9fb-f214-4432-b2a7-91e603e00e60

３adminログアウトして、userのログイン状況を確認

https://github.com/YoshikiWarashina/Kita/assets/129946179/4550e08f-cc47-432e-9fc1-a644e6797ba3

４ 3の逆 userログアウトして、adminのログイン状況を確認

https://github.com/YoshikiWarashina/Kita/assets/129946179/c74aa39d-da4f-480f-a007-7badfac24bcb

ログインしている場合・していない場合
<img width="1089" alt="スクリーンショット 2023-08-22 14 15 44" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/29d754cb-2b4d-41cd-8a1a-cf07fc7465a6">
<img width="1066" alt="スクリーンショット 2023-08-22 14 16 09" src="https://github.com/YoshikiWarashina/Kita/assets/129946179/629bd685-969c-44b5-93ce-231bbce67f09">

